### PR TITLE
Double count empty string pnc

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/CourtCaseEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/CourtCaseEventsService.kt
@@ -56,7 +56,7 @@ class CourtCaseEventsService(
             offenderService.processAssociatedOffenders(it, person)
             prisonerService.processAssociatedPrisoners(it, person)
           }
-        }
+        } // what if defendants is not empty?
       }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/CourtCaseEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/CourtCaseEventsService.kt
@@ -19,7 +19,7 @@ class CourtCaseEventsService(
   private val prisonerService: PrisonerService,
 ) {
 
-  private val pncIdValidator: PNCIdValidator = PNCIdValidator()
+  private val pncIdValidator: PNCIdValidator = PNCIdValidator(telemetryService)
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
   }
@@ -27,38 +27,28 @@ class CourtCaseEventsService(
   @Transactional(isolation = Isolation.SERIALIZABLE)
   fun processPersonFromCourtCaseEvent(person: Person) {
     log.debug("Entered processPersonFromCourtCaseEvent")
-
-    // Ensure PNC is present
-    if (person.otherIdentifiers?.pncNumber.isNullOrEmpty()) {
-      log.info("PNC not present in court case event - no further processing will occur")
-      telemetryService.trackEvent(TelemetryEventType.NEW_CASE_MISSING_PNC, emptyMap())
+    val pnc: String? = person.otherIdentifiers?.pncNumber
+    // Validate PNC
+    if (!pncIdValidator.isValid(pnc)) {
+      return
     }
+    val defendants = personRepository.findByDefendantsPncNumber(pnc!!)?.defendants.orEmpty()
 
-    person.otherIdentifiers?.pncNumber?.let { pnc ->
-      // Validate PNC
-      if (!pncIdValidator.isValid(pnc)) {
-        log.info("Invalid PNC $pnc encountered in court case event - no further processing will occur")
-        telemetryService.trackEvent(TelemetryEventType.NEW_CASE_INVALID_PNC, mapOf("PNC" to pnc))
-      } else {
-        val defendants = personRepository.findByDefendantsPncNumber(pnc)?.defendants.orEmpty()
-
-        if (matchesExistingRecordExactly(defendants, person)) {
-          log.info("Exactly matching Person record exists with defendant - no further processing will occur")
-          telemetryService.trackEvent(TelemetryEventType.NEW_CASE_EXACT_MATCH, mapOf("PNC" to pnc, "CRN" to defendants[0].crn, "UUID" to person.personId.toString()))
-        } else if (matchesExistingRecordPartially(defendants, person)) {
-          log.info("Partially matching Person record exists with defendant - no further processing will occur")
-          telemetryService.trackEvent(TelemetryEventType.NEW_CASE_PARTIAL_MATCH, extractMatchingFields(defendants[0], person))
-        } else if (defendants.isEmpty()) {
-          log.debug("No existing matching Person record exists - creating new person and defendant with pnc $pnc")
-          val personRecord = personRecordService.createNewPersonAndDefendant(person)
-          telemetryService.trackEvent(TelemetryEventType.NEW_CASE_PERSON_CREATED, mapOf("UUID" to personRecord.personId.toString(), "PNC" to pnc))
-          personRecord.let {
-            offenderService.processAssociatedOffenders(it, person)
-            prisonerService.processAssociatedPrisoners(it, person)
-          }
-        } // what if defendants is not empty?
+    if (matchesExistingRecordExactly(defendants, person)) {
+      log.info("Exactly matching Person record exists with defendant - no further processing will occur")
+      telemetryService.trackEvent(TelemetryEventType.NEW_CASE_EXACT_MATCH, mapOf("PNC" to pnc, "CRN" to defendants[0].crn, "UUID" to person.personId.toString()))
+    } else if (matchesExistingRecordPartially(defendants, person)) {
+      log.info("Partially matching Person record exists with defendant - no further processing will occur")
+      telemetryService.trackEvent(TelemetryEventType.NEW_CASE_PARTIAL_MATCH, extractMatchingFields(defendants[0], person))
+    } else if (defendants.isEmpty()) {
+      log.debug("No existing matching Person record exists - creating new person and defendant with pnc $pnc")
+      val personRecord = personRecordService.createNewPersonAndDefendant(person)
+      telemetryService.trackEvent(TelemetryEventType.NEW_CASE_PERSON_CREATED, mapOf("UUID" to personRecord.personId.toString(), "PNC" to pnc))
+      personRecord.let {
+        offenderService.processAssociatedOffenders(it, person)
+        prisonerService.processAssociatedPrisoners(it, person)
       }
-    }
+    } // what if defendants is not empty?
   }
 
   private fun extractMatchingFields(defendant: DefendantEntity, person: Person): Map<String, String?> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/validate/PNCIdValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/validate/PNCIdValidator.kt
@@ -15,10 +15,11 @@ class PNCIdValidator(private val telemetryService: TelemetryService) {
       return false
     }
     val result = isValidFormat(pncIdentifier) && hasValidCheckDigit(pncIdentifier)
-    if (!result) {
-      telemetryService.trackEvent(TelemetryEventType.NEW_CASE_INVALID_PNC, mapOf("PNC" to pncIdentifier))
+    return result.also {
+      if (!it) {
+        telemetryService.trackEvent(TelemetryEventType.NEW_CASE_INVALID_PNC, mapOf("PNC" to pncIdentifier))
+      }
     }
-    return result
   }
 
   private fun hasValidCheckDigit(pncIdentifier: String): Boolean {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/CourtCaseEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/CourtCaseEventsServiceTest.kt
@@ -54,7 +54,7 @@ class CourtCaseEventsServiceTest {
   }
 
   @Test
-  fun `should call telemetry service when PNC is empty`() { //failing test to show double counting of empty string pnc
+  fun `should call telemetry service when PNC is empty`() { // failing test to show double counting of empty string pnc
     // Given
     val person = Person(familyName = "Jones", otherIdentifiers = OtherIdentifiers(pncNumber = ""))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/CourtCaseEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/CourtCaseEventsServiceTest.kt
@@ -54,6 +54,20 @@ class CourtCaseEventsServiceTest {
   }
 
   @Test
+  fun `should call telemetry service when PNC is empty`() { //failing test to show double counting of empty string pnc
+    // Given
+    val person = Person(familyName = "Jones", otherIdentifiers = OtherIdentifiers(pncNumber = ""))
+
+    // When
+    courtCaseEventsService.processPersonFromCourtCaseEvent(person)
+
+    // Then
+    verify(personRecordService, never()).createNewPersonAndDefendant(person)
+    verify(telemetryService).trackEvent(TelemetryEventType.NEW_CASE_MISSING_PNC, emptyMap())
+    verify(telemetryService, never()).trackEvent(TelemetryEventType.NEW_CASE_INVALID_PNC, mapOf("PNC" to ""))
+  }
+
+  @Test
   fun `should call telemetry service when PNC is invalid from Court Case Event`() {
     // Given
     val pncNumber = "DODGY_PNC"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/validate/PNCIdValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/validate/PNCIdValidatorTest.kt
@@ -2,13 +2,27 @@ package uk.gov.justice.digital.hmpps.personrecord.validate
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import uk.gov.justice.digital.hmpps.personrecord.service.TelemetryService
 
+@ExtendWith(MockitoExtension::class)
 class PNCIdValidatorTest {
 
-  private val pncIdValidator: PNCIdValidator = PNCIdValidator()
+  @Mock
+  lateinit var telemetryService: TelemetryService
+
+  private lateinit var pncIdValidator: PNCIdValidator
+
+  @BeforeEach
+  fun setUp() {
+    pncIdValidator = PNCIdValidator(telemetryService)
+  }
 
   @ParameterizedTest
   @ValueSource(strings = ["", "0", "01", "012", "0123", "01234", "012345", "0123567", "012345678", "0123456789", "01234567890", "01234567890123"])

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -14,6 +14,10 @@
         <appender-ref ref="CONSOLE"/>
     </logger>
 
+    <logger name="com.zaxxer" additivity="false" level="ERROR">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
     <logger name="org.apache" additivity="false" level="ERROR">
         <appender-ref ref="CONSOLE"/>
     </logger>


### PR DESCRIPTION
At the moment, an empty string PNC is treated as both missing and invalid (see the test added in this PR).