### PR TITLE
CPR-145 remove limit of max messages - does not solve the JPA problems

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/CourtCaseEventsListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/CourtCaseEventsListener.kt
@@ -27,7 +27,7 @@ class CourtCaseEventsListener(
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  @SqsListener(CPR_COURT_CASE_EVENTS_QUEUE_CONFIG_KEY, factory = "hmppsQueueContainerFactoryProxy", maxConcurrentMessages = "1", maxMessagesPerPoll = "1")
+  @SqsListener(CPR_COURT_CASE_EVENTS_QUEUE_CONFIG_KEY, factory = "hmppsQueueContainerFactoryProxy")
   @WithSpan(value = "hmpps-person-record-cpr_court_case_events_queue", kind = SpanKind.SERVER)
   fun onMessage(
     rawMessage: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/CourtCaseEventsListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/CourtCaseEventsListenerIntTest.kt
@@ -7,6 +7,7 @@ import org.awaitility.kotlin.untilAsserted
 import org.awaitility.kotlin.untilCallTo
 import org.awaitility.kotlin.untilNotNull
 import org.jmock.lib.concurrent.Blitzer
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.check
 import org.mockito.kotlin.eq
@@ -32,7 +33,6 @@ import uk.gov.justice.digital.hmpps.personrecord.validate.PNCIdentifier
 import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
 import java.time.LocalDate
 import java.util.concurrent.TimeUnit
-import kotlin.test.Ignore
 
 @Sql(
   scripts = ["classpath:sql/before-test.sql"],
@@ -155,7 +155,7 @@ class CourtCaseEventsListenerIntTest : IntegrationTestBase() {
   }
 
   @Test
-  @Ignore
+  @Disabled
   fun `should not push messages onto dead letter queue when processing fails because of could not serialize access due to read write dependencies among transactions`() {
     // given
     val pncNumber = "2003/0062845E"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/CourtCaseEventsListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/CourtCaseEventsListenerIntTest.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.personrecord.validate.PNCIdentifier
 import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
 import java.time.LocalDate
 import java.util.concurrent.TimeUnit
+import kotlin.test.Ignore
 
 @Sql(
   scripts = ["classpath:sql/before-test.sql"],
@@ -154,6 +155,7 @@ class CourtCaseEventsListenerIntTest : IntegrationTestBase() {
   }
 
   @Test
+  @Ignore
   fun `should not push messages onto dead letter queue when processing fails because of could not serialize access due to read write dependencies among transactions`() {
     // given
     val pncNumber = "2003/0062845E"


### PR DESCRIPTION
Almost 400 of the errors in the last 12 hours, so reverting this change as it doesn't seem to help