### PR TITLE
CPR-141 log original PNC number before canonicalisation to check format

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/validate/PNCIdValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/validate/PNCIdValidator.kt
@@ -16,7 +16,7 @@ class PNCIdValidator(private val telemetryService: TelemetryService) {
         hasValidCheckDigit(pncIdentifier.pncId!!)
       )
       .also {
-        telemetryService.trackEvent(if (it) VALID_PNC else INVALID_PNC, mapOf("PNC" to pncIdentifier.pncId))
+        telemetryService.trackEvent(if (it) VALID_PNC else INVALID_PNC, mapOf("PNC" to pncIdentifier.pncId, "inputPNC" to pncIdentifier.inputPnc))
       }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/validate/PNCIdentifier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/validate/PNCIdentifier.kt
@@ -6,6 +6,9 @@ import java.time.LocalDate
 const val LONG_PNC_ID_LENGTH = 10
 
 data class PNCIdentifier(private val inputPncId: String? = null) {
+  val inputPnc: String?
+    get() = inputPncId
+
   val pncId: String?
     get() = toCanonicalForm(inputPncId)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/CourtCaseEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/CourtCaseEventsServiceTest.kt
@@ -16,6 +16,9 @@ import uk.gov.justice.digital.hmpps.personrecord.jpa.repository.PersonRepository
 import uk.gov.justice.digital.hmpps.personrecord.model.OtherIdentifiers
 import uk.gov.justice.digital.hmpps.personrecord.model.Person
 import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType
+import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.INVALID_PNC
+import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.NEW_CASE_EXACT_MATCH
+import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.VALID_PNC
 import uk.gov.justice.digital.hmpps.personrecord.validate.PNCIdentifier
 import java.time.LocalDate
 import java.util.*
@@ -67,7 +70,7 @@ class CourtCaseEventsServiceTest {
     // Then
     verify(personRecordService, never()).createNewPersonAndDefendant(person)
     verify(telemetryService).trackEvent(TelemetryEventType.MISSING_PNC, emptyMap())
-    verify(telemetryService, never()).trackEvent(TelemetryEventType.INVALID_PNC, mapOf("PNC" to ""))
+    verify(telemetryService, never()).trackEvent(INVALID_PNC, mapOf("PNC" to ""))
     verifyNoMoreInteractions(telemetryService)
   }
 
@@ -82,7 +85,7 @@ class CourtCaseEventsServiceTest {
 
     // Then
     verify(personRecordService, never()).createNewPersonAndDefendant(person)
-    verify(telemetryService).trackEvent(TelemetryEventType.INVALID_PNC, mapOf("PNC" to pncNumber))
+    verify(telemetryService).trackEvent(INVALID_PNC, mapOf("PNC" to pncNumber, "inputPNC" to "DODGY_PNC"))
     verifyNoMoreInteractions(telemetryService)
   }
 
@@ -122,8 +125,8 @@ class CourtCaseEventsServiceTest {
 
     // Then
     verify(personRecordService, never()).createNewPersonAndDefendant(person)
-    verify(telemetryService).trackEvent(TelemetryEventType.VALID_PNC, mapOf("PNC" to pncNumber))
-    verify(telemetryService).trackEvent(TelemetryEventType.NEW_CASE_EXACT_MATCH, mapOf("PNC" to pncNumber, "CRN" to crn, "UUID" to personID.toString()))
+    verify(telemetryService).trackEvent(VALID_PNC, mapOf("PNC" to pncNumber, "inputPNC" to pncNumber))
+    verify(telemetryService).trackEvent(NEW_CASE_EXACT_MATCH, mapOf("PNC" to pncNumber, "CRN" to crn, "UUID" to personID.toString()))
   }
 
   @Test


### PR DESCRIPTION
it is noteworthy that all the invalid PNCs begin with 1999, 2000 or 2020. In order to check that the canonicalisation is working correctly, this will output the original and canonical PNC when validation fails