### PR TITLE
FIX: suppress unchecked cast warning

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/AuthAwareTokenConverter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/AuthAwareTokenConverter.kt
@@ -15,6 +15,7 @@ class AuthAwareTokenConverter : Converter<Jwt, AbstractAuthenticationToken> {
   }
 
   private fun extractAuthorities(jwt: Jwt): Collection<GrantedAuthority> {
+    @Suppress("UNCHECKED_CAST")
     val authorities = jwt.claims.getOrDefault("authorities", emptyList<String>()) as Collection<String>
     return authorities.map { SimpleGrantedAuthority(it) }
   }


### PR DESCRIPTION
This warning seems OK to suppress based on this search - everyone is doing it:

https://github.com/search?q=UNCHECKED_CAST+path%3A**%2FAuthAwareTokenConverter.kt+language%3AKotlin&type=code&ref=advsearch

It is the only warning we had, so it should be simple to spot if we introduce any new ones