### PR TITLE
FIX: only notify slack for production releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,8 +73,6 @@ workflows:
           jira_update: true
           pipeline_id: <<pipeline.id>>
           pipeline_number: <<pipeline.number>>
-          slack_notification: true
-          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
           context: hmpps-common-vars
           filters:
             branches:
@@ -95,8 +93,6 @@ workflows:
           jira_update: true
           pipeline_id: <<pipeline.id>>
           pipeline_number: <<pipeline.number>>
-          slack_notification: true
-          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
           jira_env_type: staging
           context:
             - hmpps-common-vars


### PR DESCRIPTION
There are too many alerts in the alerts channel for my liking - we do not need to know about dev and preprod releases.
I also wonder about moving the production release notifications into the general channel