### PR TITLE
CPR-307 set alerts for old messages back to the default of 30 minutes

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -32,6 +32,5 @@ generic-prometheus-alerts:
     - "hmpps-person-record-development-cpr_delius_offender_events_dlq"
     - "hmpps-person-record-development-cpr_nomis_events_dlq"
   sqsAlertsTotalMessagesThreshold: 1
-  sqsAlertsOldestThreshold: 2
   rdsAlertsDatabases:
     cloud-platform-21758fcf16e3a488: "hmpps-person-record-database"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -24,6 +24,5 @@ generic-prometheus-alerts:
     - "hmpps-person-record-preprod-cpr_delius_offender_events_dlq"
     - "hmpps-person-record-preprod-cpr_nomis_events_dlq"
   sqsAlertsTotalMessagesThreshold: 1
-  sqsAlertsOldestThreshold: 2
   rdsAlertsDatabases:
     cloud-platform-288cab966b34da54: "hmpps-person-record-database"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -24,6 +24,5 @@ generic-prometheus-alerts:
     - "hmpps-person-record-prod-cpr_delius_offender_events_dlq"
     - "hmpps-person-record-prod-cpr_nomis_events_dlq"
   sqsAlertsTotalMessagesThreshold: 1
-  sqsAlertsOldestThreshold: 2
   rdsAlertsDatabases:
     cloud-platform-325c1d58e0fe99fe: "hmpps-person-record-database"


### PR DESCRIPTION
If we have a serious problem, the numberOfMessagesOnQueue alert should fire anyway. This was firing when we were slowly processing large volumes of messages - we already knew we had a problem, but processing was actually working. The alert didn't tell us anything new.