### PR TITLE
FIX: more prisoner to prison renaming

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/prison/PrisonDomainEventListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/prison/PrisonDomainEventListenerTest.kt
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.hmpps.personrecord.service.EventKeys
 import uk.gov.justice.digital.hmpps.personrecord.service.TelemetryService
 import uk.gov.justice.digital.hmpps.personrecord.service.type.PRISONER_CREATED
 import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType
-import uk.gov.justice.digital.hmpps.personrecord.test.messages.prisonerDomainEvent
+import uk.gov.justice.digital.hmpps.personrecord.test.messages.prisonDomainEvent
 import java.util.UUID
 import kotlin.test.assertFailsWith
 
@@ -44,7 +44,7 @@ class PrisonDomainEventListenerTest {
     // given
     val prisonNumber = UUID.randomUUID().toString()
     val messageId = UUID.randomUUID().toString()
-    val rawMessage = prisonerDomainEvent(PRISONER_CREATED, prisonNumber, messageId = messageId)
+    val rawMessage = prisonDomainEvent(PRISONER_CREATED, prisonNumber, messageId = messageId)
     whenever(prisonEventProcessor.processEvent(any())).thenThrow(IllegalArgumentException("Something went wrong"))
     // when
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/test/messages/DomainEventMessages.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/test/messages/DomainEventMessages.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.personrecord.test.messages
 
-fun prisonerDomainEvent(eventType: String?, prisonNumber: String, messageId: String?) = """
+fun prisonDomainEvent(eventType: String?, prisonNumber: String, messageId: String?) = """
   {
     "Type": "Notification",
     "MessageId": "$messageId",


### PR DESCRIPTION
I think this is it - now the word `prisoner` actually refers to an individual in prison throughout our code