### PR TITLE
CPR-297 add a test coverage report

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
   kotlin("jvm") version "2.0.0"
   kotlin("plugin.jpa") version "2.0.0"
   id("io.gitlab.arturbosch.detekt") version "1.23.6"
+  id("org.jetbrains.kotlinx.kover") version "0.7.6"
 }
 
 configurations {
@@ -71,6 +72,7 @@ detekt {
 tasks {
   getByName("check") {
     dependsOn(":ktlintCheck", "detekt")
+    finalizedBy("koverHtmlReport")
   }
 }
 


### PR DESCRIPTION
Generates an HTML report showing test coverage. If we like this, we could get it published in the build, but it might be more useful to run locally. At the moment it runs after check (and seems quick) but it's not worth slowing the build down for