### PR TITLE
PI-2291 Update Probation Integration paged response model

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/model/ProbationCases.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/model/ProbationCases.kt
@@ -2,14 +2,12 @@ package uk.gov.justice.digital.hmpps.personrecord.client.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
+import org.springframework.data.web.PagedModel.PageMetadata
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCase
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ProbationCases(
-
-  val totalPages: Int,
-  val first: Boolean,
-  val last: Boolean,
+  val page: PageMetadata,
   @JsonProperty("content")
   val cases: List<ProbationCase>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/seeding/PopulateFromProbation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/seeding/PopulateFromProbation.kt
@@ -39,7 +39,7 @@ class PopulateFromProbation(
           0,
           pageSize,
         ),
-      )?.totalPages ?: 1
+      )?.page?.totalPages?.toInt() ?: 1
 
       log.info("Starting DELIUS seeding, total pages: $totalPages")
       for (page in 0..<totalPages) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/test/responses/AllProbationCasesResponses.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/test/responses/AllProbationCasesResponses.kt
@@ -19,32 +19,15 @@ fun allProbationCasesSingleResponse(firstCrn: String, firstPrefix: String) = """
             },
             "aliases": [],
             "addresses": []
-        }],
-    "pageable": {
-        "pageNumber": 6004,
-        "pageSize": 100,
-        "sort": {
-            "unsorted": false,
-            "sorted": true,
-            "empty": false
-        },
-        "offset": 600400,
-        "paged": true,
-        "unpaged": false
-    },
-    "totalElements": 7,
-    "totalPages": 4,
-    "last": false,
-    "numberOfElements": 2,
-    "first": true,
-    "size": 2,
-    "number": 1,
-    "sort": {
-        "unsorted": false,
-        "sorted": true,
-        "empty": false
- },
-    "empty": false}
+        }
+    ],
+    "page": {
+        "size": 1,
+        "number": 1,
+        "totalElements": 1,
+        "totalPages": 1
+    }
+ }
 """.trimIndent()
 
 fun allProbationCasesResponse(firstCrn: String, firstPrefix: String, secondCrn: String, secondPrefix: String, totalPages: Int = 4) = """
@@ -93,30 +76,13 @@ fun allProbationCasesResponse(firstCrn: String, firstPrefix: String, secondCrn: 
             },
             "aliases": [],
             "addresses": []
-        }],
-    "pageable": {
-        "pageNumber": 6004,
-        "pageSize": 100,
-        "sort": {
-            "unsorted": false,
-            "sorted": true,
-            "empty": false
-        },
-        "offset": 600400,
-        "paged": true,
-        "unpaged": false
-    },
-    "totalElements": 7,
-    "totalPages": $totalPages,
-    "last": false,
-    "numberOfElements": 2,
-    "first": true,
-    "size": 2,
-    "number": 1,
-    "sort": {
-        "unsorted": false,
-        "sorted": true,
-        "empty": false
- },
-    "empty": false}
+        }
+    ],
+    "page": {
+        "size": 2,
+        "number": 10,
+        "totalElements": 102,
+        "totalPages": $totalPages
+    }
+ }
 """.trimIndent()


### PR DESCRIPTION
We are updating the probation-integration API to return Spring's PagedModel type, instead of the raw PageImpl type (see https://docs.spring.io/spring-data/commons/reference/repositories/core-extensions.html#core.web.page.paged-model).

This is technically a breaking change, however given this endpoint is only called on an ad hoc basis, it seemed simpler to just co-ordinate the API and client changes.