### PR TITLE
CPR-215 Reduce joins on address table on queries

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/PersonSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/PersonSpecification.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.personrecord.jpa.repository.specifications
 
 import jakarta.persistence.criteria.Join
-import jakarta.persistence.criteria.JoinType
+import jakarta.persistence.criteria.JoinType.INNER
 import jakarta.persistence.criteria.Predicate
 import org.springframework.data.jpa.domain.Specification
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.AddressEntity
@@ -48,7 +48,7 @@ object PersonSpecification {
   fun levenshteinPostcodes(postcodes: List<String>, limit: Int = 2): Specification<PersonEntity> {
     return Specification { root, _, criteriaBuilder ->
       postcodes.takeIf { it.isNotEmpty() }?.let {
-        val addressJoin: Join<PersonEntity, AddressEntity> = root.join("addresses", JoinType.INNER)
+        val addressJoin: Join<PersonEntity, AddressEntity> = root.join("addresses", INNER)
         val postcodePredicates: Array<Predicate> = postcodes.map {
           criteriaBuilder.le(
             criteriaBuilder.function("levenshtein", Integer::class.java, criteriaBuilder.literal(it), addressJoin.get<String>(POSTCODE)),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/PersonSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/PersonSpecification.kt
@@ -45,7 +45,7 @@ object PersonSpecification {
     }
   }
 
-  fun levenshteinPostcodes(postcodes: List<String>, limit: Int = 2): Specification<PersonEntity> {
+  fun levenshteinPostcodes(postcodes: Set<String>, limit: Int = 2): Specification<PersonEntity> {
     return Specification { root, _, criteriaBuilder ->
       postcodes.takeIf { it.isNotEmpty() }?.let {
         val addressJoin: Join<PersonEntity, AddressEntity> = root.join("addresses", INNER)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/queries/PersonSpecificationQueries.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/queries/PersonSpecificationQueries.kt
@@ -12,14 +12,14 @@ import uk.gov.justice.digital.hmpps.personrecord.jpa.repository.specifications.P
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Person
 
 fun findCandidates(person: Person): Specification<PersonEntity> {
-  val postcodeSpecifications = person.addresses.map { PersonSpecification.levenshteinPostcode(it.postcode) }
+  val postcodes = person.addresses.mapNotNull { it.postcode }
 
   val soundexFirstLastName = Specification.where(
     PersonSpecification.soundex(person.firstName, PersonSpecification.FIRST_NAME)
       .and(PersonSpecification.soundex(person.lastName, PersonSpecification.LAST_NAME)),
   )
   val levenshteinDob = Specification.where(PersonSpecification.levenshteinDate(person.dateOfBirth, PersonSpecification.DOB))
-  val levenshteinPostcode = Specification.where(PersonSpecification.combineSpecificationsWithOr(postcodeSpecifications))
+  val levenshteinPostcode = Specification.where(PersonSpecification.levenshteinPostcodes(postcodes))
   return Specification.where(
     exactMatch(person.otherIdentifiers?.pncIdentifier?.toString(), PNC)
       .or(exactMatch(person.driverLicenseNumber, DRIVER_LICENSE_NUMBER))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/queries/PersonSpecificationQueries.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/queries/PersonSpecificationQueries.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.personrecord.jpa.repository.specifications.P
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Person
 
 fun findCandidates(person: Person): Specification<PersonEntity> {
-  val postcodes = person.addresses.mapNotNull { it.postcode }
+  val postcodes = person.addresses.mapNotNull { it.postcode }.toSet()
 
   val soundexFirstLastName = Specification.where(
     PersonSpecification.soundex(person.firstName, PersonSpecification.FIRST_NAME)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/SearchServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/SearchServiceIntTest.kt
@@ -384,6 +384,49 @@ class SearchServiceIntTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `should find candidate records on Levenshtein matches on multiple postcodes`() {
+    val firstName = randomFirstName()
+    createPerson(
+      Person(
+        firstName = firstName,
+        lastName = "Smythe",
+        addresses = listOf(
+          Address(postcode = "LS2 1AB"),
+          Address(postcode = "LS3 1AB"),
+          Address(postcode = "LS4 1AB"),
+        ),
+        sourceSystemType = HMCTS,
+      ),
+    )
+    createPerson(
+      Person(
+        firstName = firstName,
+        lastName = "Smythe",
+        addresses = listOf(Address(postcode = "PR7 3DU")),
+        sourceSystemType = HMCTS,
+      ),
+    )
+
+    val searchingPerson = Person(
+      firstName = firstName,
+      lastName = "Smith",
+      addresses = listOf(
+        Address(postcode = "LS5 1AC"),
+        Address(postcode = "LD2 3BC")),
+      sourceSystemType = HMCTS,
+    )
+
+    val matchResponse = MatchResponse(matchProbabilities = mutableMapOf("0" to 0.9999999))
+    stubMatchScore(matchResponse)
+    val candidateRecords = searchService.findCandidateRecords(searchingPerson)
+
+    assertThat(candidateRecords.size).isEqualTo(1)
+    assertThat(candidateRecords[0].candidateRecord.addresses[0].postcode).isEqualTo("LS2 1AB")
+    assertThat(candidateRecords[0].candidateRecord.addresses[1].postcode).isEqualTo("LS3 1AB")
+    assertThat(candidateRecords[0].candidateRecord.addresses[2].postcode).isEqualTo("LS4 1AB")
+  }
+
+  @Test
   fun `should not find candidate records on matching postcode but not name`() {
     createPerson(
       Person(


### PR DESCRIPTION
* Only does 1 join on the address table, rather than previously creating a join for each incoming postcode