### PR TITLE
FIX: remove unused dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,6 @@ dependencies {
   testImplementation("org.jetbrains.kotlin:kotlin-test-junit:2.0.0")
   testImplementation("org.awaitility:awaitility-kotlin:4.2.1")
   testImplementation("org.jmock:jmock:2.13.1")
-  testImplementation("io.hypersistence:hypersistence-utils-hibernate-63:3.8.0")
 }
 
 java {


### PR DESCRIPTION
I noticed we got an update for this test dependency and it looked unfamiliar - turns out we don't need it to make the tests pass