### PR TITLE
CPR-388 Remove detail URL

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/model/sqs/domainevent/DomainEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/model/sqs/domainevent/DomainEvent.kt
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonProperty
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class DomainEvent @JsonCreator constructor(
   @JsonProperty("eventType") val eventType: String,
-  @JsonProperty("detailUrl") val detailUrl: String,
   @JsonProperty("personReference") val personReference: PersonReference? = null,
   @JsonProperty("additionalInformation") val additionalInformation: AdditionalInformation? = null,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/MessagingMultiNodeTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/MessagingMultiNodeTestBase.kt
@@ -152,7 +152,6 @@ abstract class MessagingMultiNodeTestBase : IntegrationTestBase() {
 
     val domainEvent = DomainEvent(
       eventType = eventType,
-      detailUrl = createDeliusDetailUrl(crn),
       personReference = personReference,
       additionalInformation = additionalInformation,
     )
@@ -213,12 +212,6 @@ abstract class MessagingMultiNodeTestBase : IntegrationTestBase() {
         ),
     )
   }
-
-  fun createDeliusDetailUrl(crn: String): String =
-    "https://domain-events-and-delius-dev.hmpps.service.justice.gov.uk/probation-case.engagement.created/$crn"
-
-  fun createNomsDetailUrl(prisonNumber: String): String =
-    "https://prisoner-search-dev.prison.service.justice.gov.uk/prisoner/$prisonNumber"
 
   @BeforeEach
   fun beforeEachMessagingTest() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/prison/PrisonEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/prison/PrisonEventListenerIntTest.kt
@@ -58,7 +58,7 @@ class PrisonEventListenerIntTest : MessagingMultiNodeTestBase() {
     stubPrisonResponse(ApiResponseSetup(prisonNumber = prisonNumber, pnc = pnc, email = email, cro = cro, addresses = listOf(ApiResponseSetupAddress(postcode)), prefix = prefix, dateOfBirth = personDateOfBirth))
 
     val additionalInformation = AdditionalInformation(prisonNumber = prisonNumber, categoriesChanged = emptyList())
-    val domainEvent = DomainEvent(eventType = PRISONER_CREATED, detailUrl = createNomsDetailUrl(prisonNumber), personReference = null, additionalInformation = additionalInformation)
+    val domainEvent = DomainEvent(eventType = PRISONER_CREATED, personReference = null, additionalInformation = additionalInformation)
     publishDomainEvent(PRISONER_CREATED, domainEvent)
 
     checkTelemetry(MESSAGE_RECEIVED, mapOf("PRISON_NUMBER" to prisonNumber, "EVENT_TYPE" to PRISONER_CREATED, "SOURCE_SYSTEM" to "NOMIS"))
@@ -104,7 +104,7 @@ class PrisonEventListenerIntTest : MessagingMultiNodeTestBase() {
     stubPrisonResponse(ApiResponseSetup(prisonNumber = prisonNumber))
 
     val additionalInformation = AdditionalInformation(prisonNumber = prisonNumber, categoriesChanged = emptyList())
-    val domainEvent = DomainEvent(eventType = PRISONER_CREATED, detailUrl = createNomsDetailUrl(prisonNumber), personReference = null, additionalInformation = additionalInformation)
+    val domainEvent = DomainEvent(eventType = PRISONER_CREATED, personReference = null, additionalInformation = additionalInformation)
     publishDomainEvent(PRISONER_CREATED, domainEvent)
 
     checkTelemetry(MESSAGE_RECEIVED, mapOf("PRISON_NUMBER" to prisonNumber, "EVENT_TYPE" to PRISONER_CREATED, "SOURCE_SYSTEM" to "NOMIS"))
@@ -126,7 +126,7 @@ class PrisonEventListenerIntTest : MessagingMultiNodeTestBase() {
     stubPrisonResponse(ApiResponseSetup(prisonNumber = prisonNumber))
 
     val additionalInformation = AdditionalInformation(prisonNumber = prisonNumber, categoriesChanged = listOf("SENTENCE"))
-    val domainEvent = DomainEvent(eventType = PRISONER_UPDATED, detailUrl = createNomsDetailUrl(prisonNumber), personReference = null, additionalInformation = additionalInformation)
+    val domainEvent = DomainEvent(eventType = PRISONER_UPDATED, personReference = null, additionalInformation = additionalInformation)
     publishDomainEvent(PRISONER_UPDATED, domainEvent)
 
     checkTelemetry(MESSAGE_RECEIVED, mapOf("PRISON_NUMBER" to prisonNumber, "EVENT_TYPE" to PRISONER_UPDATED, "SOURCE_SYSTEM" to "NOMIS"))
@@ -143,7 +143,7 @@ class PrisonEventListenerIntTest : MessagingMultiNodeTestBase() {
     stub500Response(prisonNumber, "next request will succeed")
     stubPrisonResponse(ApiResponseSetup(prisonNumber = prisonNumber), scenarioName = "retry", currentScenarioState = "next request will succeed")
     val additionalInformation = AdditionalInformation(prisonNumber = prisonNumber, categoriesChanged = listOf("SENTENCE"))
-    val domainEvent = DomainEvent(eventType = PRISONER_CREATED, detailUrl = createNomsDetailUrl(prisonNumber), personReference = null, additionalInformation = additionalInformation)
+    val domainEvent = DomainEvent(eventType = PRISONER_CREATED, personReference = null, additionalInformation = additionalInformation)
     publishDomainEvent(PRISONER_CREATED, domainEvent)
 
     checkTelemetry(MESSAGE_RECEIVED, mapOf("PRISON_NUMBER" to prisonNumber, "EVENT_TYPE" to PRISONER_CREATED, "SOURCE_SYSTEM" to "NOMIS"))
@@ -165,7 +165,7 @@ class PrisonEventListenerIntTest : MessagingMultiNodeTestBase() {
     stub500Response(prisonNumber, STARTED)
     stub500Response(prisonNumber, STARTED)
     val additionalInformation = AdditionalInformation(prisonNumber = prisonNumber, categoriesChanged = listOf("SENTENCE"))
-    val domainEvent = DomainEvent(eventType = PRISONER_CREATED, detailUrl = createNomsDetailUrl(prisonNumber), personReference = null, additionalInformation = additionalInformation)
+    val domainEvent = DomainEvent(eventType = PRISONER_CREATED, personReference = null, additionalInformation = additionalInformation)
     val messageId = publishDomainEvent(PRISONER_CREATED, domainEvent)
 
     prisonEventsQueue!!.sqsClient.purgeQueue(
@@ -192,7 +192,7 @@ class PrisonEventListenerIntTest : MessagingMultiNodeTestBase() {
     stubPrisonResponse(ApiResponseSetup(prisonNumber = prisonNumber))
 
     val additionalInformation = AdditionalInformation(prisonNumber = prisonNumber, categoriesChanged = emptyList())
-    val domainEvent = DomainEvent(eventType = PRISONER_UPDATED, detailUrl = createNomsDetailUrl(prisonNumber), personReference = null, additionalInformation = additionalInformation)
+    val domainEvent = DomainEvent(eventType = PRISONER_UPDATED, personReference = null, additionalInformation = additionalInformation)
     publishDomainEvent(PRISONER_UPDATED, domainEvent)
 
     checkTelemetry(MESSAGE_RECEIVED, mapOf("PRISON_NUMBER" to prisonNumber, "EVENT_TYPE" to PRISONER_UPDATED, "SOURCE_SYSTEM" to "NOMIS"))
@@ -212,7 +212,7 @@ class PrisonEventListenerIntTest : MessagingMultiNodeTestBase() {
     val prisonNumber = randomPrisonNumber()
     probationDomainEventAndResponseSetup(eventType = OFFENDER_ALIAS_CHANGED, pnc = "", prisonNumber = prisonNumber)
     val additionalInformation = AdditionalInformation(prisonNumber = prisonNumber, categoriesChanged = emptyList())
-    val domainEvent = DomainEvent(eventType = PRISONER_CREATED, detailUrl = createNomsDetailUrl(prisonNumber), personReference = null, additionalInformation = additionalInformation)
+    val domainEvent = DomainEvent(eventType = PRISONER_CREATED, personReference = null, additionalInformation = additionalInformation)
 
     stubPrisonResponse(ApiResponseSetup(prisonNumber = prisonNumber))
     publishDomainEvent(PRISONER_UPDATED, domainEvent)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListenerIntTest.kt
@@ -124,7 +124,7 @@ class ProbationEventListenerIntTest : MessagingMultiNodeTestBase() {
 
     val crnType = PersonIdentifier("CRN", crn)
     val personReference = PersonReference(listOf(crnType))
-    val domainEvent = DomainEvent(eventType = NEW_OFFENDER_CREATED, detailUrl = createDeliusDetailUrl(crn), personReference = personReference, additionalInformation = null)
+    val domainEvent = DomainEvent(eventType = NEW_OFFENDER_CREATED, personReference = personReference, additionalInformation = null)
     publishDomainEvent(NEW_OFFENDER_CREATED, domainEvent)
 
     await.atMost(Duration.ofSeconds(2)) untilCallTo {
@@ -165,7 +165,6 @@ class ProbationEventListenerIntTest : MessagingMultiNodeTestBase() {
 
     val domainEvent = DomainEvent(
       eventType = NEW_OFFENDER_CREATED,
-      detailUrl = createDeliusDetailUrl(crn),
       personReference = personReference,
       additionalInformation = null,
     )


### PR DESCRIPTION
Errors caused in DEV when messages fail to have `detailUrl`. As well as we don't use the property so might as well remove it.