### PR TITLE
FIX: only retry tests when CI env variable is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ```
 $ make test
 ```
+Some tests are a bit flaky so are automatically retried in CI. If you want this feature locally, run `CI=true make test`
 
 ## Deployment
 
@@ -76,9 +77,4 @@ Then you can run AWS CLI commands on the pod like this:
 `AWS_REGION=eu-west-2 AWS_ACCESS_KEY_ID=key AWS_SECRET_ACCESS_KEY=secret aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name cpr_court_events_queue.fifo --attributes '{"FifoQueue": "true", "ContentBasedDeduplication": "true"}'`
 
 `AWS_REGION=eu-west-2 AWS_ACCESS_KEY_ID=key AWS_SECRET_ACCESS_KEY=secret aws --endpoint-url=http://localhost:4566 sns subscribe --topic-arn arn:aws:sns:eu-west-2:000000000000:courteventstopic.fifo --protocol sqs --notification-endpoint arn:aws:sqs:eu-west-2:000000000000:cpr_court_events_queue.fifo`
-
-
-
-would have to change Cloud platform SNS module
-
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,7 +76,9 @@ tasks {
 
   withType(Test::class) {
     retry {
-      maxRetries.set(3)
+      if (environment.get("CI") == "true") {
+        maxRetries.set(3)
+      }
     }
   }
 }


### PR DESCRIPTION
When a test fails in IntelliJ, there's not much point in running it 3 times.
