### PR TITLE
CPR-453 Use postgres similarity to reduce number records on search

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/entity/PersonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/entity/PersonEntity.kt
@@ -93,6 +93,9 @@ class PersonEntity(
   @Column(name = "date_of_birth")
   var dateOfBirth: LocalDate? = null,
 
+  @Column(name = "date_of_birth_text")
+  var dateOfBirthText: String? = null,
+
   @Column
   val sex: String? = null,
 
@@ -189,6 +192,7 @@ class PersonEntity(
         middleNames = person.middleNames?.joinToString(" ") { it },
         lastName = person.lastName,
         dateOfBirth = person.dateOfBirth,
+        dateOfBirthText = person.dateOfBirth.toString(),
         defendantId = person.defendantId,
         crn = person.crn,
         prisonNumber = person.prisonNumber,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/PersonSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/PersonSpecification.kt
@@ -23,15 +23,32 @@ object PersonSpecification {
 
   const val FIRST_NAME = "firstName"
   const val LAST_NAME = "lastName"
-  const val DOB = "dateOfBirth"
+  const val DOB = "dateOfBirthText"
   const val SOURCE_SYSTEM = "sourceSystem"
 
   private const val IDENTIFIER_TYPE = "identifierType"
   private const val IDENTIFIER_VALUE = "identifierValue"
   private const val PERSON_KEY = "personKey"
   private const val POSTCODE = "postcode"
-  private const val DATE_FORMAT = "YYYY-MM-DD"
   private const val MERGED_TO = "mergedTo"
+
+  private const val SIMILARITY_THRESHOLD = 0.6
+
+  fun checkSimilarity(input: String?, field: String): Specification<PersonEntity> {
+    return Specification { root, _, criteriaBuilder ->
+      input?.let {
+        criteriaBuilder.greaterThanOrEqualTo(
+          criteriaBuilder.function(
+            "similarity",
+            Double::class.java,
+            root.get<String>(field),
+            criteriaBuilder.literal(it),
+          ),
+          SIMILARITY_THRESHOLD,
+        )
+      } ?: criteriaBuilder.disjunction()
+    }
+  }
 
   fun exactMatch(input: String?, field: String): Specification<PersonEntity> {
     return Specification { root, _, criteriaBuilder ->
@@ -72,9 +89,20 @@ object PersonSpecification {
       postcodes.takeIf { it.isNotEmpty() }?.let {
         val addressJoin: Join<PersonEntity, AddressEntity> = root.join("addresses", LEFT)
         val postcodePredicates: Array<Predicate> = postcodes.map {
-          criteriaBuilder.le(
-            criteriaBuilder.function("levenshtein_less_equal", Integer::class.java, criteriaBuilder.literal(it), addressJoin.get<String>(POSTCODE), criteriaBuilder.literal(limit)),
-            limit,
+          criteriaBuilder.and(
+            criteriaBuilder.greaterThanOrEqualTo(
+              criteriaBuilder.function(
+                "similarity",
+                Double::class.java,
+                addressJoin.get<String>(POSTCODE),
+                criteriaBuilder.literal(it),
+              ),
+              SIMILARITY_THRESHOLD,
+            ),
+            criteriaBuilder.le(
+              criteriaBuilder.function("levenshtein_less_equal", Integer::class.java, criteriaBuilder.literal(it), addressJoin.get<String>(POSTCODE), criteriaBuilder.literal(limit)),
+              limit,
+            ),
           )
         }.toTypedArray()
         criteriaBuilder.or(*postcodePredicates)
@@ -85,15 +113,9 @@ object PersonSpecification {
   fun levenshteinDate(input: LocalDate?, field: String, limit: Int = 2): Specification<PersonEntity> {
     return Specification { root, _, criteriaBuilder ->
       input?.let {
-        val dbDateAsString = criteriaBuilder.function(
-          "TO_CHAR",
-          String::class.java,
-          root.get<LocalDate>(field),
-          criteriaBuilder.literal(DATE_FORMAT),
-        )
         criteriaBuilder.le(
           criteriaBuilder.function(
-            "levenshtein_less_equal", Integer::class.java, criteriaBuilder.literal(input.toString()), dbDateAsString, criteriaBuilder.literal(limit),
+            "levenshtein_less_equal", Integer::class.java, criteriaBuilder.literal(input.toString()), root.get<String>(field), criteriaBuilder.literal(limit),
           ),
           limit,
         )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/queries/PersonSpecificationQueries.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/queries/PersonSpecificationQueries.kt
@@ -4,7 +4,6 @@ import org.springframework.data.jpa.domain.Specification
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.PersonEntity
 import uk.gov.justice.digital.hmpps.personrecord.jpa.repository.specifications.PersonSpecification
 import uk.gov.justice.digital.hmpps.personrecord.jpa.repository.specifications.PersonSpecification.SOURCE_SYSTEM
-import uk.gov.justice.digital.hmpps.personrecord.jpa.repository.specifications.PersonSpecification.checkSimilarity
 import uk.gov.justice.digital.hmpps.personrecord.jpa.repository.specifications.PersonSpecification.exactMatch
 import uk.gov.justice.digital.hmpps.personrecord.jpa.repository.specifications.PersonSpecification.exactMatchReferences
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Person
@@ -21,11 +20,9 @@ private fun findCandidates(person: Person): Specification<PersonEntity> {
   val levenshteinPostcode = Specification.where(PersonSpecification.levenshteinPostcodes(postcodes))
 
   return Specification.where(
-    checkSimilarity(person.dateOfBirth.toString(), PersonSpecification.DOB).and(
-      exactMatchReferences(references)
-        .or(soundexFirstLastName.and(levenshteinDob.or(levenshteinPostcode)))
-        .and(PersonSpecification.isNotMerged()),
-    ),
+    exactMatchReferences(references)
+      .or(soundexFirstLastName.and(levenshteinDob.or(levenshteinPostcode)))
+      .and(PersonSpecification.isNotMerged()),
   )
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/queries/PersonSpecificationQueries.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/queries/PersonSpecificationQueries.kt
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.domain.Specification
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.PersonEntity
 import uk.gov.justice.digital.hmpps.personrecord.jpa.repository.specifications.PersonSpecification
 import uk.gov.justice.digital.hmpps.personrecord.jpa.repository.specifications.PersonSpecification.SOURCE_SYSTEM
+import uk.gov.justice.digital.hmpps.personrecord.jpa.repository.specifications.PersonSpecification.checkSimilarity
 import uk.gov.justice.digital.hmpps.personrecord.jpa.repository.specifications.PersonSpecification.exactMatch
 import uk.gov.justice.digital.hmpps.personrecord.jpa.repository.specifications.PersonSpecification.exactMatchReferences
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Person
@@ -20,9 +21,11 @@ private fun findCandidates(person: Person): Specification<PersonEntity> {
   val levenshteinPostcode = Specification.where(PersonSpecification.levenshteinPostcodes(postcodes))
 
   return Specification.where(
-    exactMatchReferences(references)
-      .or(soundexFirstLastName.and(levenshteinDob.or(levenshteinPostcode)))
-      .and(PersonSpecification.isNotMerged()),
+    checkSimilarity(person.dateOfBirth.toString(), PersonSpecification.DOB).and(
+      exactMatchReferences(references)
+        .or(soundexFirstLastName.and(levenshteinDob.or(levenshteinPostcode)))
+        .and(PersonSpecification.isNotMerged()),
+    ),
   )
 }
 

--- a/src/main/resources/db/migration/V60__add_trigram_filtering.sql
+++ b/src/main/resources/db/migration/V60__add_trigram_filtering.sql
@@ -3,8 +3,11 @@ BEGIN;
 
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 ALTER TABLE personrecordservice.person ADD COLUMN date_of_birth_text text default NULL;
+
 CREATE INDEX trgm_index_postcode ON personrecordservice.address USING gin (postcode gin_trgm_ops);
 CREATE INDEX trgm_index_date_of_birth ON personrecordservice.person USING gin (date_of_birth_text gin_trgm_ops);
+
+UPDATE personrecordservice.person SET date_of_birth_text = to_char(personrecordservice.person.date_of_birth, 'YYYY-MM-DD');
 
 -------------------------------------------------------
 COMMIT;

--- a/src/main/resources/db/migration/V60__add_trigram_filtering.sql
+++ b/src/main/resources/db/migration/V60__add_trigram_filtering.sql
@@ -1,0 +1,10 @@
+BEGIN;
+-------------------------------------------------------
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+ALTER TABLE personrecordservice.person ADD COLUMN date_of_birth_text text default NULL;
+CREATE INDEX trgm_index_postcode ON personrecordservice.address USING gin (postcode gin_trgm_ops);
+CREATE INDEX trgm_index_date_of_birth ON personrecordservice.person USING gin (date_of_birth_text gin_trgm_ops);
+
+-------------------------------------------------------
+COMMIT;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/SearchServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/SearchServiceIntTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.personrecord.model.types.SourceSystemType.DE
 import uk.gov.justice.digital.hmpps.personrecord.model.types.SourceSystemType.LIBRA
 import uk.gov.justice.digital.hmpps.personrecord.model.types.SourceSystemType.NOMIS
 import uk.gov.justice.digital.hmpps.personrecord.test.randomCro
+import uk.gov.justice.digital.hmpps.personrecord.test.randomDate
 import uk.gov.justice.digital.hmpps.personrecord.test.randomDriverLicenseNumber
 import uk.gov.justice.digital.hmpps.personrecord.test.randomName
 import uk.gov.justice.digital.hmpps.personrecord.test.randomNationalInsuranceNumber
@@ -410,6 +411,35 @@ class SearchServiceIntTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `should find candidate records on Levenshtein matches on dob but not postcode`() {
+    val firstName = randomName()
+    createPerson(
+      Person(
+        firstName = firstName,
+        lastName = "Smith",
+        dateOfBirth = LocalDate.of(1975, 1, 1),
+        addresses = listOf(Address(postcode = randomPostcode())),
+        sourceSystemType = COMMON_PLATFORM,
+      ),
+    )
+
+    val searchingPerson = Person(
+      firstName = firstName,
+      lastName = "Smith",
+      dateOfBirth = LocalDate.of(1975, 2, 1),
+      addresses = listOf(Address(postcode = randomPostcode())),
+      sourceSystemType = COMMON_PLATFORM,
+    )
+
+    val matchResponse = MatchResponse(matchProbabilities = mutableMapOf("0" to 0.9999999))
+    stubMatchScore(matchResponse)
+    val candidateRecords = searchService.findCandidateRecordsBySourceSystem(searchingPerson)
+
+    assertThat(candidateRecords.size).isEqualTo(1)
+    assertThat(candidateRecords[0].candidateRecord.dateOfBirth).isEqualTo(LocalDate.of(1975, 1, 1))
+  }
+
+  @Test
   fun `should find candidate records on names matches and dob when other record has fields with joins`() {
     val firstName = randomName()
     val lastName = randomName()
@@ -466,6 +496,35 @@ class SearchServiceIntTest : IntegrationTestBase() {
     val searchingPerson = Person(
       firstName = firstName,
       lastName = "Smith",
+      addresses = listOf(Address(postcode = "LS2 1AB"), Address(postcode = "LD2 3BC")),
+      sourceSystemType = COMMON_PLATFORM,
+    )
+
+    val matchResponse = MatchResponse(matchProbabilities = mutableMapOf("0" to 0.9999999))
+    stubMatchScore(matchResponse)
+    val candidateRecords = searchService.findCandidateRecordsBySourceSystem(searchingPerson)
+
+    assertThat(candidateRecords.size).isEqualTo(1)
+    assertThat(candidateRecords[0].candidateRecord.addresses[0].postcode).isEqualTo("LS1 1AB")
+  }
+
+  @Test
+  fun `should find candidate records on Levenshtein matches on postcode but not dob`() {
+    val firstName = randomName()
+    createPerson(
+      Person(
+        firstName = firstName,
+        lastName = "Smythe",
+        dateOfBirth = randomDate(),
+        addresses = listOf(Address(postcode = "LS1 1AB")),
+        sourceSystemType = COMMON_PLATFORM,
+      ),
+    )
+
+    val searchingPerson = Person(
+      firstName = firstName,
+      lastName = "Smith",
+      dateOfBirth = randomDate(),
       addresses = listOf(Address(postcode = "LS2 1AB"), Address(postcode = "LD2 3BC")),
       sourceSystemType = COMMON_PLATFORM,
     )


### PR DESCRIPTION
* Use postgres https://www.postgresql.org/docs/current/pgtrgm.html trigram function to reduce the number of rows passed to the Levenshtein function. Includes indexes on the frequently used searched columns. Hopefully, speeding up the query / message processing.