### PR TITLE
CPR-453 retry on 502

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/PersonSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/PersonSpecification.kt
@@ -1,13 +1,11 @@
 package uk.gov.justice.digital.hmpps.personrecord.jpa.repository.specifications
 
 import jakarta.persistence.criteria.Join
-import jakarta.persistence.criteria.JoinType.INNER
 import jakarta.persistence.criteria.JoinType.LEFT
 import jakarta.persistence.criteria.Predicate
 import org.springframework.data.jpa.domain.Specification
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.AddressEntity
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.PersonEntity
-import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.PersonKeyEntity
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.ReferenceEntity
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Reference
 import uk.gov.justice.digital.hmpps.personrecord.model.types.IdentifierType
@@ -105,8 +103,7 @@ object PersonSpecification {
 
   fun hasPersonKey(): Specification<PersonEntity> {
     return Specification { root, _, criteriaBuilder ->
-      val personKeyJoin: Join<PersonEntity, PersonKeyEntity> = root.join(PERSON_KEY, INNER)
-      criteriaBuilder.isNotNull(personKeyJoin)
+      criteriaBuilder.isNotNull(root.get<Long>(PERSON_KEY))
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/RetryExecutor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/RetryExecutor.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.delay
 import kotlin.reflect.KClass
 
 object RetryExecutor {
-  private val retryables = listOf(feign.RetryableException::class, FeignException.InternalServerError::class, FeignException.ServiceUnavailable::class)
+  private val retryables = listOf(feign.RetryableException::class, FeignException.InternalServerError::class, FeignException.ServiceUnavailable::class, FeignException.BadGateway::class)
   suspend fun <T> runWithRetry(
     maxAttempts: Int,
     delay: Long,


### PR DESCRIPTION
* Shouldnt push to DLQ if next request succeeds from a 502. We only see a fraction of 502's (250 out of 250,000 requests)