### PR TITLE
CPR-453 remove levenshtein func from query

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/PersonSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/PersonSpecification.kt
@@ -17,7 +17,7 @@ import java.time.LocalDate
 
 object PersonSpecification {
 
-  const val SEARCH_VERSION = "1.5"
+  const val SEARCH_VERSION = "2"
 
   val SEARCH_IDENTIFIERS = listOf(PNC, CRO, NATIONAL_INSURANCE_NUMBER, DRIVER_LICENSE_NUMBER)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/queries/PersonSpecificationQueries.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/specifications/queries/PersonSpecificationQueries.kt
@@ -16,12 +16,12 @@ private fun findCandidates(person: Person): Specification<PersonEntity> {
     PersonSpecification.soundex(person.firstName, PersonSpecification.FIRST_NAME)
       .and(PersonSpecification.soundex(person.lastName, PersonSpecification.LAST_NAME)),
   )
-  val levenshteinDob = Specification.where(PersonSpecification.levenshteinDate(person.dateOfBirth, PersonSpecification.DOB))
-  val levenshteinPostcode = Specification.where(PersonSpecification.levenshteinPostcodes(postcodes))
+  val hasTwoDateParts = Specification.where(PersonSpecification.matchDateParts(person.dateOfBirth, PersonSpecification.DOB))
+  val matchesPostcodePrefix = Specification.where(PersonSpecification.exactMatchPostcodePrefix(postcodes))
 
   return Specification.where(
     exactMatchReferences(references)
-      .or(soundexFirstLastName.and(levenshteinDob.or(levenshteinPostcode)))
+      .or(soundexFirstLastName.and(hasTwoDateParts.or(matchesPostcodePrefix)))
       .and(PersonSpecification.isNotMerged()),
   )
 }

--- a/src/main/resources/db/migration/V60__add_postcode_index.sql
+++ b/src/main/resources/db/migration/V60__add_postcode_index.sql
@@ -3,5 +3,9 @@ BEGIN;
 
 create index idx_postcode_left on personrecordservice.address (LEFT(postcode, 3));
 
+create index idx_dob_year on personrecordservice.person (date_part('YEAR', date_of_birth));
+create index idx_dob_month on personrecordservice.person (date_part('MONTH', date_of_birth));
+create index idx_dob_day on personrecordservice.person (date_part('DAY', date_of_birth));
+
 ----------------------------------------
 COMMIT;

--- a/src/main/resources/db/migration/V60__add_postcode_index.sql
+++ b/src/main/resources/db/migration/V60__add_postcode_index.sql
@@ -1,0 +1,7 @@
+BEGIN;
+----------------------------------------
+
+create index idx_postcode_left on personrecordservice.address (LEFT(postcode, 3));
+
+----------------------------------------
+COMMIT;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/SearchServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/SearchServiceIntTest.kt
@@ -466,7 +466,7 @@ class SearchServiceIntTest : IntegrationTestBase() {
     val searchingPerson = Person(
       firstName = firstName,
       lastName = "Smith",
-      addresses = listOf(Address(postcode = "LS2 1AB"), Address(postcode = "LD2 3BC")),
+      addresses = listOf(Address(postcode = "LS1 2AB"), Address(postcode = "LD2 3BC")),
       sourceSystemType = COMMON_PLATFORM,
     )
 
@@ -508,7 +508,7 @@ class SearchServiceIntTest : IntegrationTestBase() {
       firstName = firstName,
       lastName = "Smith",
       addresses = listOf(
-        Address(postcode = "LS5 1AB"),
+        Address(postcode = "LS2 2AB"),
         Address(postcode = "LD2 3BC"),
       ),
       sourceSystemType = COMMON_PLATFORM,

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -75,6 +75,8 @@ spring:
       read-timeout: 300
       default-request-headers:
         Accept: application/json
+  jpa:
+    show-sql: true
   flyway:
     out-of-order: true
   datasource:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -75,8 +75,6 @@ spring:
       read-timeout: 300
       default-request-headers:
         Accept: application/json
-  jpa:
-    show-sql: true
   flyway:
     out-of-order: true
   datasource:


### PR DESCRIPTION
Example resulting query:
```
select pe1_0.id,pe1_0.birth_country,pe1_0.birth_place,pe1_0.crn,pe1_0.currently_managed,pe1_0.date_of_birth,pe1_0.defendant_id,pe1_0.ethnicity,pe1_0.first_name,pe1_0.last_name,pe1_0.master_defendant_id,pe1_0.merged_to,pe1_0.middle_names,pe1_0.nationality,pe1_0.fk_person_key_id,pe1_0.prison_number,pe1_0.religion,pe1_0.self_match_score,pe1_0.sex,pe1_0.sexual_orientation,pe1_0.source_system,pe1_0.title,pe1_0.version 
from personrecordservice.person pe1_0 
left join personrecordservice.reference r1_0 
on pe1_0.id=r1_0.fk_person_id 
left join personrecordservice.address a1_0 
on pe1_0.id=a1_0.fk_person_id 
where 
	(personrecordservice.soundex(pe1_0.first_name)=personrecordservice.soundex('twqnkwb') 
	and personrecordservice.soundex(pe1_0.last_name)=personrecordservice.soundex('oxxtksz') 
	and (
		date_part('YEAR',pe1_0.date_of_birth)=1975 and date_part('MONTH',pe1_0.date_of_birth)=1 or 
		date_part('YEAR',pe1_0.date_of_birth)=1975 and date_part('DAY',pe1_0.date_of_birth)=1 or
		date_part('MONTH',pe1_0.date_of_birth)=1 and date_part('DAY',pe1_0.date_of_birth)=1 
		or left(a1_0.postcode,3)='LS1'
	)) 
	and pe1_0.merged_to is null 
	and pe1_0.source_system='COMMON_PLATFORM';

select date_part('year',p.date_of_birth)
from personrecordservice.person p;
```