### PR TITLE
CPR-438 Handle multiple results when reclustering

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/person/ReclusterService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/person/ReclusterService.kt
@@ -17,9 +17,9 @@ import uk.gov.justice.digital.hmpps.personrecord.service.TelemetryService
 import uk.gov.justice.digital.hmpps.personrecord.service.search.MatchService
 import uk.gov.justice.digital.hmpps.personrecord.service.search.SearchService
 import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_RECLUSTER_CLUSTER_RECORDS_NOT_LINKED
+import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_RECLUSTER_MATCH_FOUND_MERGE
 import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_RECLUSTER_NO_CHANGE
 import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_RECLUSTER_NO_MATCH_FOUND
-import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_RECLUSTER_MATCH_FOUND_MERGE
 import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_RECLUSTER_STARTED
 import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_RECLUSTER_UUID_MARKED_NEEDS_ATTENTION
 import java.util.UUID

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/type/TelemetryEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/type/TelemetryEventType.kt
@@ -32,5 +32,5 @@ enum class TelemetryEventType(val eventName: String) {
   CPR_RECLUSTER_NO_CHANGE("CprReclusterNoChange"),
   CPR_RECLUSTER_CLUSTER_RECORDS_NOT_LINKED("CprReclusterClusterRecordsNotLinked"),
   CPR_RECLUSTER_NO_MATCH_FOUND("CprReclusterNoMatchFound"),
-  CPR_RECLUSTER_SINGLE_MATCH_FOUND_MERGE("CprReclusterSingleMatchFoundMergeRecluster"),
+  CPR_RECLUSTER_MATCH_FOUND_MERGE("CprReclusterMatchFoundMergeRecluster"),
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/ReclusterServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/ReclusterServiceIntTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.personrecord.service
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.untilNotNull
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.personrecord.client.MatchResponse
@@ -20,12 +21,16 @@ import uk.gov.justice.digital.hmpps.personrecord.model.types.SourceSystemType.NO
 import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusType
 import uk.gov.justice.digital.hmpps.personrecord.service.person.ReclusterService
 import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType
-import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_CANDIDATE_RECORD_SEARCH
 import uk.gov.justice.digital.hmpps.personrecord.test.randomCRN
 import uk.gov.justice.digital.hmpps.personrecord.test.randomCro
 import uk.gov.justice.digital.hmpps.personrecord.test.randomName
 
 class ReclusterServiceIntTest : IntegrationTestBase() {
+
+  @BeforeEach
+  fun beforeEach() {
+    telemetryRepository.deleteAll()
+  }
 
   @Autowired
   private lateinit var reclusterService: ReclusterService

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/ReclusterServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/ReclusterServiceIntTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.personrecord.model.types.SourceSystemType.NO
 import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusType
 import uk.gov.justice.digital.hmpps.personrecord.service.person.ReclusterService
 import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType
+import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_CANDIDATE_RECORD_SEARCH
 import uk.gov.justice.digital.hmpps.personrecord.test.randomCRN
 import uk.gov.justice.digital.hmpps.personrecord.test.randomCro
 import uk.gov.justice.digital.hmpps.personrecord.test.randomName
@@ -66,11 +67,23 @@ class ReclusterServiceIntTest : IntegrationTestBase() {
       ),
       personKeyEntity = cluster1,
     )
-    val matchResponse = MatchResponse(matchProbabilities = mutableMapOf("0" to 0.99999999))
-    stubMatchScore(matchResponse)
 
     reclusterService.recluster(cluster1.personId)
 
+    checkTelemetry(
+      TelemetryEventType.CPR_RECLUSTER_STARTED,
+      mapOf("UUID" to cluster1.personId.toString()),
+    )
+    checkTelemetry(
+      CPR_CANDIDATE_RECORD_SEARCH,
+      mapOf(
+        "SOURCE_SYSTEM" to COMMON_PLATFORM.name,
+        "RECORD_COUNT" to "0",
+        "UUID_COUNT" to "0",
+        "HIGH_CONFIDENCE_COUNT" to "0",
+        "LOW_CONFIDENCE_COUNT" to "0",
+      ),
+    )
     checkTelemetry(
       TelemetryEventType.CPR_RECLUSTER_NO_MATCH_FOUND,
       mapOf("UUID" to cluster1.personId.toString()),
@@ -101,7 +114,6 @@ class ReclusterServiceIntTest : IntegrationTestBase() {
     val matchResponse = MatchResponse(
       matchProbabilities = mutableMapOf(
         "0" to 0.999999,
-        "1" to 0.999999,
       ),
     )
     stubMatchScore(matchResponse)
@@ -121,6 +133,16 @@ class ReclusterServiceIntTest : IntegrationTestBase() {
     val targetCluster = await untilNotNull { personKeyRepository.findByPersonId(cluster2.personId) }
     assertThat(targetCluster.personEntities.size).isEqualTo(2)
 
+    checkTelemetry(
+      CPR_CANDIDATE_RECORD_SEARCH,
+      mapOf(
+        "SOURCE_SYSTEM" to COMMON_PLATFORM.name,
+        "RECORD_COUNT" to "1",
+        "UUID_COUNT" to "1",
+        "HIGH_CONFIDENCE_COUNT" to "1",
+        "LOW_CONFIDENCE_COUNT" to "0",
+      ),
+    )
     checkTelemetry(
       TelemetryEventType.CPR_RECLUSTER_MATCH_FOUND_MERGE,
       mapOf(
@@ -170,7 +192,6 @@ class ReclusterServiceIntTest : IntegrationTestBase() {
         "0" to 0.999999,
         "1" to 0.999999,
         "2" to 0.999999,
-        "3" to 0.999999,
       ),
     )
     stubMatchScore(matchResponse)
@@ -190,6 +211,16 @@ class ReclusterServiceIntTest : IntegrationTestBase() {
     val targetCluster = await untilNotNull { personKeyRepository.findByPersonId(cluster2.personId) }
     assertThat(targetCluster.personEntities.size).isEqualTo(4)
 
+    checkTelemetry(
+      CPR_CANDIDATE_RECORD_SEARCH,
+      mapOf(
+        "SOURCE_SYSTEM" to COMMON_PLATFORM.name,
+        "RECORD_COUNT" to "3",
+        "UUID_COUNT" to "1",
+        "HIGH_CONFIDENCE_COUNT" to "3",
+        "LOW_CONFIDENCE_COUNT" to "0",
+      ),
+    )
     checkTelemetry(
       TelemetryEventType.CPR_RECLUSTER_MATCH_FOUND_MERGE,
       mapOf(
@@ -237,9 +268,8 @@ class ReclusterServiceIntTest : IntegrationTestBase() {
     val matchResponse = MatchResponse(
       matchProbabilities = mutableMapOf(
         "0" to 0.999999,
-        "1" to 0.999999,
+        "1" to 0.788888,
         "2" to 0.788888,
-        "3" to 0.788888,
       ),
     )
     stubMatchScore(matchResponse)
@@ -259,6 +289,16 @@ class ReclusterServiceIntTest : IntegrationTestBase() {
     val targetCluster = await untilNotNull { personKeyRepository.findByPersonId(cluster2.personId) }
     assertThat(targetCluster.personEntities.size).isEqualTo(4)
 
+    checkTelemetry(
+      CPR_CANDIDATE_RECORD_SEARCH,
+      mapOf(
+        "SOURCE_SYSTEM" to COMMON_PLATFORM.name,
+        "RECORD_COUNT" to "3",
+        "UUID_COUNT" to "1",
+        "HIGH_CONFIDENCE_COUNT" to "1",
+        "LOW_CONFIDENCE_COUNT" to "2",
+      ),
+    )
     checkTelemetry(
       TelemetryEventType.CPR_RECLUSTER_MATCH_FOUND_MERGE,
       mapOf(
@@ -300,9 +340,8 @@ class ReclusterServiceIntTest : IntegrationTestBase() {
 
     val matchResponse = MatchResponse(
       matchProbabilities = mutableMapOf(
-        "0" to 0.999999,
-        "1" to 0.9999993,
-        "2" to 0.9999992,
+        "0" to 0.9999999,
+        "1" to 0.9999991,
       ),
     )
     stubMatchScore(matchResponse)
@@ -325,6 +364,16 @@ class ReclusterServiceIntTest : IntegrationTestBase() {
     val unaffectedCluster = await untilNotNull { personKeyRepository.findByPersonId(cluster3.personId) }
     assertThat(unaffectedCluster.personEntities.size).isEqualTo(1)
 
+    checkTelemetry(
+      CPR_CANDIDATE_RECORD_SEARCH,
+      mapOf(
+        "SOURCE_SYSTEM" to COMMON_PLATFORM.name,
+        "RECORD_COUNT" to "2",
+        "UUID_COUNT" to "2",
+        "HIGH_CONFIDENCE_COUNT" to "2",
+        "LOW_CONFIDENCE_COUNT" to "0",
+      ),
+    )
     checkTelemetry(
       TelemetryEventType.CPR_RECLUSTER_MATCH_FOUND_MERGE,
       mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/SearchServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/SearchServiceIntTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.personrecord.service
 
 import com.github.tomakehurst.wiremock.client.WireMock
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.personrecord.client.MatchResponse
@@ -27,6 +28,11 @@ import uk.gov.justice.digital.hmpps.personrecord.test.randomPostcode
 import java.time.LocalDate
 
 class SearchServiceIntTest : IntegrationTestBase() {
+
+  @BeforeEach
+  fun beforeEach() {
+    telemetryRepository.deleteAll()
+  }
 
   @Autowired
   private lateinit var searchService: SearchService


### PR DESCRIPTION
* Made results handle same for all results as extra complexity required to log certain scenarios with single/multiple clusters, which we can easily determine from the candidate record search event