### PR TITLE
CPR-503 check whether containers are running before trying to start them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 test: start-containers format
 	./gradlew check
 
@@ -5,7 +6,13 @@ format:
 	./gradlew ktlintFormat
 
 start-containers:
+ifeq (0,$(shell docker compose ps --services --filter "status=running" | grep 'hmpps-person-record' | wc -l | xargs))
 	docker compose up -d
+else
+	@echo "containers already running"
+endif
+
+
 
 stop-containers:
 	docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
 
-  postgres:
+  postgres-hmpps-person-record:
     image: postgres:16.1-alpine
     ports:
       - 5432:5432


### PR DESCRIPTION
NB this renames the postgres container so if you already have them running, please run `docker compose down` first as the script relies on the container naming. I was struggling to run this when I had containers running from other projects.
Please pull this and check it works for you locally.

```mark.rees@MJ004359 hmpps-person-record % make start-containers
docker compose up -d
[+] Running 3/3
 ✔ Network hmpps-person-record_hmpps                             Created                                                                                                                                 0.0s 
 ✔ Container hmpps-person-record-postgres-hmpps-person-record-1  Started                                                                                                                                 0.1s 
 ✔ Container localstack-hmpps-person-record                      Started                                                                                                                                 0.1s 
mark.rees@MJ004359 hmpps-person-record % make start-containers
containers already running