### PR TITLE
CPR-503 add eventType attribute to recluster messages so we can ident…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/queue/QueueService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/queue/QueueService.kt
@@ -8,6 +8,7 @@ import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 import uk.gov.justice.digital.hmpps.personrecord.client.model.court.MessageType
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.NOTIFICATION
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.Recluster
+import uk.gov.justice.digital.hmpps.personrecord.service.type.RECLUSTER_EVENT
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.MissingQueueException
 import uk.gov.justice.hmpps.sqs.MissingTopicException
@@ -48,16 +49,16 @@ class QueueService(
       .messageBody(message)
       .messageAttributes(
         mapOf(
-          attribute("eventType", "recluster.required"),
-          attribute("messageType", NOTIFICATION),
-          attribute("messageId", UUID.randomUUID().toString()),
+          sqsAttribute("eventType", RECLUSTER_EVENT),
+          sqsAttribute("messageType", NOTIFICATION),
+          sqsAttribute("messageId", UUID.randomUUID().toString()),
         ),
       )
 
     queue.sqsClient.sendMessage(messageBuilder.build())
   }
 
-  private fun attribute(key: String, value: String): Pair<String, MessageAttributeValue> = key to SQSMessageAttribute.builder().dataType("String")
+  private fun sqsAttribute(key: String, value: String): Pair<String, MessageAttributeValue> = key to SQSMessageAttribute.builder().dataType("String")
     .stringValue(value).build()
 
   private fun findByTopicIdOrThrow(topicId: String) = hmppsQueueService.findByTopicId(topicId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/cpr/ReclusterEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/cpr/ReclusterEventListenerIntTest.kt
@@ -19,10 +19,15 @@ import uk.gov.justice.digital.hmpps.personrecord.model.types.SourceSystemType.DE
 import uk.gov.justice.digital.hmpps.personrecord.model.types.SourceSystemType.LIBRA
 import uk.gov.justice.digital.hmpps.personrecord.model.types.SourceSystemType.NOMIS
 import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusType
+import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusType.NEEDS_ATTENTION
 import uk.gov.justice.digital.hmpps.personrecord.service.queue.QueueService
-import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType
 import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_CANDIDATE_RECORD_SEARCH
+import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_RECLUSTER_CLUSTER_RECORDS_NOT_LINKED
+import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_RECLUSTER_MATCH_FOUND_MERGE
 import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_RECLUSTER_MESSAGE_RECEIVED
+import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_RECLUSTER_NO_CHANGE
+import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_RECLUSTER_NO_MATCH_FOUND
+import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_RECLUSTER_UUID_MARKED_NEEDS_ATTENTION
 import uk.gov.justice.digital.hmpps.personrecord.test.randomCRN
 import uk.gov.justice.digital.hmpps.personrecord.test.randomCro
 import uk.gov.justice.digital.hmpps.personrecord.test.randomName
@@ -39,7 +44,7 @@ class ReclusterEventListenerIntTest : MessagingMultiNodeTestBase() {
 
   @Test
   fun `should log event if cluster needs attention`() {
-    val personKeyEntity = createPersonKey(status = UUIDStatusType.NEEDS_ATTENTION)
+    val personKeyEntity = createPersonKey(status = NEEDS_ATTENTION)
     createPerson(
       Person.from(ProbationCase(name = Name(firstName = randomName(), lastName = randomName()), identifiers = Identifiers(crn = randomCRN()))),
       personKeyEntity = personKeyEntity,
@@ -52,7 +57,7 @@ class ReclusterEventListenerIntTest : MessagingMultiNodeTestBase() {
       mapOf("UUID" to personKeyEntity.personId.toString()),
     )
     checkTelemetry(
-      TelemetryEventType.CPR_RECLUSTER_UUID_MARKED_NEEDS_ATTENTION,
+      CPR_RECLUSTER_UUID_MARKED_NEEDS_ATTENTION,
       mapOf("UUID" to personKeyEntity.personId.toString()),
     )
   }
@@ -86,7 +91,7 @@ class ReclusterEventListenerIntTest : MessagingMultiNodeTestBase() {
       ),
     )
     checkTelemetry(
-      TelemetryEventType.CPR_RECLUSTER_NO_MATCH_FOUND,
+      CPR_RECLUSTER_NO_MATCH_FOUND,
       mapOf("UUID" to cluster1.personId.toString()),
     )
   }
@@ -149,7 +154,7 @@ class ReclusterEventListenerIntTest : MessagingMultiNodeTestBase() {
       ),
     )
     checkTelemetry(
-      TelemetryEventType.CPR_RECLUSTER_MATCH_FOUND_MERGE,
+      CPR_RECLUSTER_MATCH_FOUND_MERGE,
       mapOf(
         "FROM_UUID" to cluster1.personId.toString(),
         "TO_UUID" to cluster2.personId.toString(),
@@ -231,7 +236,7 @@ class ReclusterEventListenerIntTest : MessagingMultiNodeTestBase() {
       ),
     )
     checkTelemetry(
-      TelemetryEventType.CPR_RECLUSTER_MATCH_FOUND_MERGE,
+      CPR_RECLUSTER_MATCH_FOUND_MERGE,
       mapOf(
         "FROM_UUID" to cluster1.personId.toString(),
         "TO_UUID" to cluster2.personId.toString(),
@@ -313,7 +318,7 @@ class ReclusterEventListenerIntTest : MessagingMultiNodeTestBase() {
       ),
     )
     checkTelemetry(
-      TelemetryEventType.CPR_RECLUSTER_MATCH_FOUND_MERGE,
+      CPR_RECLUSTER_MATCH_FOUND_MERGE,
       mapOf(
         "FROM_UUID" to cluster1.personId.toString(),
         "TO_UUID" to cluster2.personId.toString(),
@@ -394,7 +399,7 @@ class ReclusterEventListenerIntTest : MessagingMultiNodeTestBase() {
       ),
     )
     checkTelemetry(
-      TelemetryEventType.CPR_RECLUSTER_MATCH_FOUND_MERGE,
+      CPR_RECLUSTER_MATCH_FOUND_MERGE,
       mapOf(
         "FROM_UUID" to cluster1.personId.toString(),
         "TO_UUID" to cluster2.personId.toString(),
@@ -433,7 +438,7 @@ class ReclusterEventListenerIntTest : MessagingMultiNodeTestBase() {
       mapOf("UUID" to personKeyEntity.personId.toString()),
     )
     checkTelemetry(
-      TelemetryEventType.CPR_RECLUSTER_NO_CHANGE,
+      CPR_RECLUSTER_NO_CHANGE,
       mapOf("UUID" to personKeyEntity.personId.toString()),
     )
   }
@@ -480,13 +485,13 @@ class ReclusterEventListenerIntTest : MessagingMultiNodeTestBase() {
       mapOf("UUID" to personKeyEntity.personId.toString()),
     )
     checkTelemetry(
-      TelemetryEventType.CPR_RECLUSTER_CLUSTER_RECORDS_NOT_LINKED,
+      CPR_RECLUSTER_CLUSTER_RECORDS_NOT_LINKED,
       mapOf("UUID" to personKeyEntity.personId.toString()),
     )
 
     await untilAsserted {
       val cluster = personKeyRepository.findByPersonId(personKeyEntity.personId)
-      assertThat(cluster?.status).isEqualTo(UUIDStatusType.NEEDS_ATTENTION)
+      assertThat(cluster?.status).isEqualTo(NEEDS_ATTENTION)
     }
   }
 }


### PR DESCRIPTION
…ify them in AppInsights

[This](https://portal.azure.com#@747381f4-e81f-4a43-bf68-ced6a1e14edf/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fa5ddf257-3b21-4ba9-a28c-ab30f751b383%2FresourceGroups%2Fnomisapi-prod-rg%2Fproviders%2FMicrosoft.OperationalInsights%2Fworkspaces%2Fnomisapi-prod/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA5VTXU%252FCMBR991fUvWwkbOgP4GFhBUkImoG%252BktJdWCP9sO1AjT%252FeuwliiAzdU3N7zj3nnu6mxuTwUoHz7uqD7EqwQFKs6Q1MmQTS75MoLKUxLjZgnVaxBa5tEXa%252B4Q3u2nlmvdsJX5JgROfByTXXyjOhHAl6qFZBzAopVK%252BGwasHVRCnK8v3ooQzB9EVOfsdvIU5HdDxEw2Jtl9FbLV3wbWUWpkN8yttZVK3TNA8iC0UQbeleThAKz5sg5xIGauXzAtMp1EBtWZrkKB8wi0wj3q%252F%252BLsfDuk0o%252Fkio%252FN0PJktBnfpdESzVmw6Gad%252FRGZZTmet2BPbEuwaEozNbMBfyujhwP1fTgJ%252FIbCxXq2wigcHzPIyOVy05XWZXJminXykwhZfxx2pzewXR67BrfOGj%252BpZ6Z0Kz2DqrXGVlMyKdyBcV8pHHbJ8I0uhormQMAJ0Uw%252FRJbc3stP9sRZItY154hHIS9y3T7ue2A6%252BAwAA/timespan/PT1H) is showing the recluster events as court events at the moment