### PR TITLE
FIX: make restart-containers was not working for me

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,11 @@ else
 	@echo "containers already running"
 endif
 
-
-
 stop-containers:
 	docker compose down
 
-restart-containers: stop-containers start-containers
+restart-containers: stop-containers
+	docker compose up -d
 
 run-local: start-containers
 	./gradlew bootRun --args='--spring.profiles.active=local'


### PR DESCRIPTION
it was just stopping the containers, then reporting that they were already running, even though they weren't. I tried to faff with make for a bit then went for the lazy option