### PR TITLE
FIX: do not run initialiseDatabase task as part of build - only on de…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,10 @@ tasks {
     exclude("**/InitialiseDatabase.class")
   }
 
+  getByName("initialiseDatabase") {
+    onlyIf { gradle.startParameter.taskNames.contains("initialiseDatabase") }
+  }
+
   getByName("check") {
     dependsOn(":ktlintCheck", "detekt")
     finalizedBy("koverHtmlReport")


### PR DESCRIPTION
…mand

Should knock about 45 seconds off the build in CI

`./gradlew initialiseDatabase' still works and it the only way to run that task