### PR TITLE
CPR-537 fix all other statuses for currently managed

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/model/prisoner/CurrentlyManaged.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/model/prisoner/CurrentlyManaged.kt
@@ -6,10 +6,10 @@ data class CurrentlyManaged(val status: Boolean?) {
     private const val EMPTY_STATUS = ""
 
     private enum class Status(val status: String) {
-      ACTIVE_IN("Active : IN"),
-      ACTIVE_OUT("Active: OUT"),
-      INACTIVE_TRANSFER("Inactive: TRN"),
-      INACTIVE_OUT("Inactive: OUT"),
+      ACTIVE_IN("ACTIVE IN"),
+      ACTIVE_OUT("ACTIVE OUT"),
+      INACTIVE_TRANSFER("INACTIVE TRN"),
+      INACTIVE_OUT("INACTIVE OUT"),
     }
 
     fun from(inputStatus: String? = EMPTY_STATUS): CurrentlyManaged {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/prison/PrisonEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/prison/PrisonEventListenerIntTest.kt
@@ -76,7 +76,7 @@ class PrisonEventListenerIntTest : MessagingMultiNodeTestBase() {
     val sentenceStartDate = randomDate()
     val primarySentence = true
 
-    stubPrisonResponse(ApiResponseSetup(prisonNumber = prisonNumber, pnc = pnc, email = email, sentenceStartDate = sentenceStartDate, primarySentence = primarySentence, cro = cro, addresses = listOf(ApiResponseSetupAddress(postcode = postcode, fullAddress = fullAddress, startDate = LocalDate.of(1970, 1, 1), noFixedAbode = true)), prefix = prefix, dateOfBirth = personDateOfBirth, nationality = nationality, ethnicity = ethnicity, religion = religion, identifiers = listOf(ApiResponseSetupIdentifier(type = "NINO", value = nationalInsuranceNumber), ApiResponseSetupIdentifier(type = "DL", value = driverLicenseNumber))))
+    stubPrisonResponse(ApiResponseSetup(prisonNumber = prisonNumber, pnc = pnc, email = email, sentenceStartDate = sentenceStartDate, primarySentence = primarySentence, cro = cro, addresses = listOf(ApiResponseSetupAddress(postcode = postcode, fullAddress = fullAddress, startDate = LocalDate.of(1970, 1, 1), noFixedAbode = true)), prefix = prefix, dateOfBirth = personDateOfBirth, nationality = nationality, ethnicity = ethnicity, religion = religion, currentlyManaged = "ACTIVE IN", identifiers = listOf(ApiResponseSetupIdentifier(type = "NINO", value = nationalInsuranceNumber), ApiResponseSetupIdentifier(type = "DL", value = driverLicenseNumber))))
 
     val additionalInformation = AdditionalInformation(prisonNumber = prisonNumber, categoriesChanged = emptyList())
     val domainEvent = DomainEvent(eventType = PRISONER_CREATED, personReference = null, additionalInformation = additionalInformation)
@@ -118,7 +118,7 @@ class PrisonEventListenerIntTest : MessagingMultiNodeTestBase() {
       assertThat(personEntity.contacts[1].contactValue).isEqualTo("01141234567")
       assertThat(personEntity.contacts[2].contactType).isEqualTo(MOBILE)
       assertThat(personEntity.contacts[2].contactValue).isEqualTo("01141234567")
-      assertThat(personEntity.currentlyManaged).isEqualTo(null)
+      assertThat(personEntity.currentlyManaged).isEqualTo(true)
       assertThat(personEntity.sentenceInfo[0].sentenceDate).isEqualTo(sentenceStartDate)
     }
 
@@ -404,11 +404,11 @@ class PrisonEventListenerIntTest : MessagingMultiNodeTestBase() {
   companion object {
     @JvmStatic
     private fun currentlyManagedParameters(): Stream<Arguments> = Stream.of(
-      Arguments.of("Active : IN", true),
-      Arguments.of("Active: OUT", true),
-      Arguments.of("Inactive: TRN", true),
-      Arguments.of("Inactive: OUT", false),
-      Arguments.of("Inactive: IN", null),
+      Arguments.of("ACTIVE IN", true),
+      Arguments.of("ACTIVE OUT", true),
+      Arguments.of("INACTIVE TRN", true),
+      Arguments.of("INACTIVE OUT", false),
+      Arguments.of("INACTIVE IN", null),
       Arguments.of(null, null),
     )
   }


### PR DESCRIPTION
Evidence for this change:
[References in our codebase](https://github.com/search?q=org%3Aministryofjustice+%22ACTIVE+IN%22&type=code)

[Prisoner Search Swagger](https://prisoner-search-dev.prison.service.justice.gov.uk/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config#/Popular/findByPrisonNumber)

[And more specifically](https://github.com/ministryofjustice/prison-api/blob/2de6f7399ea84801c051f834594cb5507666c2f5/src/main/java/uk/gov/justice/hmpps/prison/api/model/PrisonerSearchDetails.kt#L89) albeit from prisoner-api

