### PR TITLE
CPR-512 add a logging line to show the class of the uncaught exception

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/RetryExecutor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/RetryExecutor.kt
@@ -49,7 +49,7 @@ object RetryExecutor {
             currentDelay = min((currentDelay * EXPONENTIAL_FACTOR).toLong(), maxDelayMillis)
           }
           else -> {
-            println("Failed to retry on class" + e::class)
+            log.info("Failed to retry on class" + e::class)
             throw e
           }
         }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/RetryExecutor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/RetryExecutor.kt
@@ -48,7 +48,10 @@ object RetryExecutor {
 
             currentDelay = min((currentDelay * EXPONENTIAL_FACTOR).toLong(), maxDelayMillis)
           }
-          else -> throw e
+          else -> {
+            println("Failed to retry on class" + e::class)
+            throw e
+          }
         }
       }
     }


### PR DESCRIPTION
It's hard to tell from the stacktrace which error is being caught in here, so if we log it that should allow us to add it to the list of retryable entity exceptions