### PR TITLE
CPR-508-address-fields-canonical

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/canonical/CanonicalAddress.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/canonical/CanonicalAddress.kt
@@ -7,6 +7,15 @@ data class CanonicalAddress(
   val startDate: String? = "",
   val endDate: String? = "",
   val postcode: String? = "",
+  val subBuildingName: String? = "",
+  val buildingName: String? = "",
+  val buildingNumber: String? = "",
+  val thoroughfareName: String? = "",
+  val dependentLocality: String? = "",
+  val postTown: String? = "",
+  val county: String? = "",
+  val country: String? = "",
+  val uprn: String? = "",
 ) {
   companion object {
 
@@ -15,6 +24,11 @@ data class CanonicalAddress(
       startDate = addressEntity.startDate?.toString(),
       endDate = addressEntity.endDate?.toString(),
       noFixedAbode = addressEntity.noFixedAbode.toString(),
+      buildingName = addressEntity.buildingName,
+      buildingNumber = addressEntity.buildingNumber,
+      thoroughfareName = addressEntity.thoroughfareName,
+      dependentLocality = addressEntity.dependentLocality,
+      postTown = addressEntity.postTown,
     )
     fun fromAddressEntityList(addressEntity: List<AddressEntity>): List<CanonicalAddress> = addressEntity.map { from(it) }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/SearchIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/SearchIntTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.personrecord.model.types.SourceSystemType.CO
 import uk.gov.justice.digital.hmpps.personrecord.model.types.SourceSystemType.DELIUS
 import uk.gov.justice.digital.hmpps.personrecord.model.types.SourceSystemType.LIBRA
 import uk.gov.justice.digital.hmpps.personrecord.model.types.SourceSystemType.NOMIS
+import uk.gov.justice.digital.hmpps.personrecord.test.randomBuildingNumber
 import uk.gov.justice.digital.hmpps.personrecord.test.randomCId
 import uk.gov.justice.digital.hmpps.personrecord.test.randomCrn
 import uk.gov.justice.digital.hmpps.personrecord.test.randomDate
@@ -279,10 +280,16 @@ class SearchIntTest : WebTestBase() {
     val postcode = randomPostcode()
     val nationality = randomNationality()
 
+    val buildingName = randomName()
+    val buildingNumber = randomBuildingNumber()
+    val thoroughfareName = randomName()
+    val dependentLocality = randomName()
+    val postTown = randomName()
+
     val canonicalAlias = CanonicalAlias(firstName = firstName, lastName = lastName, middleNames = middleNames, title = title)
     val canonicalReference = CanonicalReference(IdentifierType.PNC, identifierValue = pnc)
     val canonicalNationality = CanonicalNationality(nationality)
-    val canonicalAddress = CanonicalAddress(noFixedAbode = noFixAbode.toString(), startDate = startDate.toString(), endDate = endDate.toString(), postcode = postcode)
+    val canonicalAddress = CanonicalAddress(noFixedAbode = noFixAbode.toString(), startDate = startDate.toString(), endDate = endDate.toString(), postcode = postcode, buildingName = buildingName, buildingNumber = buildingNumber, thoroughfareName = thoroughfareName, dependentLocality = dependentLocality, postTown = postTown)
 
     val person = createPersonWithNewKey(
       Person(
@@ -301,7 +308,7 @@ class SearchIntTest : WebTestBase() {
         defendantId = randomDefendantId(),
         masterDefendantId = randomDefendantId(),
         aliases = listOf(Alias(firstName = firstName, middleNames = middleNames, lastName = lastName, dateOfBirth = randomDate(), title = title)),
-        addresses = listOf(Address(noFixedAbode = noFixAbode, startDate = startDate, endDate = endDate, postcode = postcode)),
+        addresses = listOf(Address(noFixedAbode = noFixAbode, startDate = startDate, endDate = endDate, postcode = postcode, buildingName = buildingName, buildingNumber = buildingNumber, thoroughfareName = thoroughfareName, dependentLocality = dependentLocality, postTown = postTown)),
         references = listOf(Reference(identifierType = canonicalReference.identifierType, identifierValue = pnc)),
 
       ),


### PR DESCRIPTION
CPR-508-address-fields-canonical add address fields to canonical api