### PR TITLE
TEST: output all current telemetry events in codebase

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/type/TelemetryEventTypeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/type/TelemetryEventTypeTest.kt
@@ -3,8 +3,51 @@ package uk.gov.justice.digital.hmpps.personrecord.service.type
 import org.junit.jupiter.api.Test
 
 class TelemetryEventTypeTest {
+
+  // Run this query, export to csv and copy into liveEvents
+  // https://portal.azure.com#@747381f4-e81f-4a43-bf68-ced6a1e14edf/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fa5ddf257-3b21-4ba9-a28c-ab30f751b383%2FresourceGroups%2Fnomisapi-prod-rg%2Fproviders%2FMicrosoft.OperationalInsights%2Fworkspaces%2Fnomisapi-prod/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAAzWLIQ6AMBAEPa84BwiegKjAIvhBKZtAQtvLXQuB8HiKQE5mxjAPB0LS6qFzhYAM8xR3jNaD%252Bp6aevXM2jFEY%252BgELspStyXX7L2V7Qa5mENqWpov%252BrbiSgP5may6F6x538FoAAAA/timespan/2024-08-26T08%3A18%3A41.000Z%2F2025-02-26T08%3A18%3A41.107Z/limit/30000
+  val liveEvents = """
+CprCandidateRecordSearch,6508689
+CprDefendantEventReceived,6748678
+CprDomainEventReceived,15432404
+CprFIFOHearingCreated,331320
+CprFIFOHearingUpdated,922278
+CprMatchCallFailed,3787
+CprMatchPersonRecordDuplicate,150846
+CprMatchScore,58730100
+CprMergeEventReceived,6342
+CprMergeRecordNotFound,179
+CprMessageProcessingFailed,50877
+CprNewRecordExists,14112
+CprReclusterClusterRecordsNotLinked,345660
+CprReclusterMatchFoundMergeRecluster,25614
+CprReclusterMessageReceived,7242924
+CprReclusterNoChange,930595
+CprReclusterNoMatchFound,2790260
+CprRecordCreated,1979449
+CprRecordMerged,1715
+CprRecordUnmerged,7
+CprRecordUpdated,13908252
+CprSplinkCandidateRecordsFoundGetUUID,135546
+CprSplinkSelfMatch,8132349
+CprSplinkSelfMatchNotCreatingUuid,67297
+CprUnmergeEventReceived,112
+CprUnmergeLinkNotFound,3
+CprUpdateRecordDoesNotExist,61207
+CprUuidCreated,1798999
+CprUuidReclusterNeedsAttention,3144128
+RetryDLQ,3228
+"""
+
   @Test
   fun `output telemetry event types`() {
-    TelemetryEventType.entries.map { it.eventName }.sorted().forEach { println(it) }
+    val codeEvents = TelemetryEventType.entries.map { it.eventName }.sorted()
+
+    val mappedLiveEvents = liveEvents
+      .split("\n")
+      .filterNot { it.isBlank() }
+      .associate { it.split(",")[0] to it.split(",")[1] }
+
+    codeEvents.filterNot { mappedLiveEvents.containsKey(it) }.forEach { println(it) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/type/TelemetryEventTypeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/type/TelemetryEventTypeTest.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.personrecord.service.type
+
+import org.junit.jupiter.api.Test
+
+class TelemetryEventTypeTest {
+  @Test
+  fun `output telemetry event types`() {
+    TelemetryEventType.entries.map { it.eventName }.sorted().forEach { println(it) }
+  }
+}


### PR DESCRIPTION
The following three events have not been output in the last six months

```
CprRecordHardDeleted
CprUUIDHardDeleted
CprUnmergeRecordNotFound
```


I would like to propose the following actions:

```
CprCandidateRecordSearch KEEP
CprDomainEventReceived REMOVE - replace with built in AppInsights
CprMatchCallFailed REMOVE - replace with built in AppInsights
CprMatchPersonRecordDuplicate KEEP
CprMatchScore KEEP
CprMergeEventReceived REMOVE - replace with built in AppInsights
CprMergeRecordNotFound KEEP
CprMessageProcessingFailed REMOVE - replace with built in AppInsights
CprNewRecordExists REMOVE - unnecessary
CprReclusterClusterRecordsNotLinked KEEP
CprReclusterMatchFoundMergeRecluster KEEP
CprReclusterMessageReceived REMOVE - replace with built in AppInsights
CprReclusterNoChange KEEP
CprReclusterNoMatchFound KEEP
CprRecordCreated KEEP
CprRecordHardDeleted REMOVE - never happens
CprRecordMerged KEEP
CprRecordUnmerged KEEP
CprRecordUpdated KEEP
CprSplinkCandidateRecordsFoundGetUUID 
CprUUIDHardDeleted REMOVE - never happens
CprUnmergeEventReceived REMOVE - replace with built in AppInsights
CprUnmergeLinkNotFound KEEP
CprUnmergeRecordNotFound REMOVE - never happens
CprUpdateRecordDoesNotExist REMOVE - unnecessary
CprUuidCreated KEEP
CprUuidReclusterNeedsAttention KEEP
```

This will save a good number of tests and attendant code complexity - which will speed up development and test runs.
We will have to change some of the dashboard queries along these lines

**BEFORE**
AppEvents
| where AppRoleName == "hmpps-person-record"
| where Name =="CprMatchCallFailed"

**AFTER**
AppDependencies
| where Success == false
| where AppRoleName == "hmpps-person-record"
| where DependencyType == "HTTP"
| where Target == "hmpps-person-match-score.hmpps.service.justice.gov.uk"
