### PR TITLE
CPR-508-update-canonical-fields

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/canonical/CanonicalIdentifiers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/canonical/CanonicalIdentifiers.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.personrecord.api.model.canonical
 
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.PersonKeyEntity
 
-data class Identifiers(
+data class CanonicalIdentifiers(
   val crns: List<String?> = emptyList(),
   val defendantIds: List<String?> = emptyList(),
   val prisonNumbers: List<String?> = emptyList(),
@@ -10,7 +10,7 @@ data class Identifiers(
 ) {
   companion object {
 
-    fun from(personKeyEntity: PersonKeyEntity): Identifiers = Identifiers(
+    fun from(personKeyEntity: PersonKeyEntity): CanonicalIdentifiers = CanonicalIdentifiers(
       crns = personKeyEntity.personEntities.mapNotNull { it.crn },
       defendantIds = personKeyEntity.personEntities.mapNotNull { it.defendantId },
       prisonNumbers = personKeyEntity.personEntities.mapNotNull { it.prisonNumber },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/canonical/CanonicalNationality.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/canonical/CanonicalNationality.kt
@@ -1,16 +1,15 @@
 package uk.gov.justice.digital.hmpps.personrecord.api.model.canonical
 
+import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.PersonEntity
 
 data class CanonicalNationality(
-  val nationality1: String? = "",
-  val nationality2: String? = "",
+  @Schema(description = "Nationality code", example = "UK")
+  val nationalityCode: String? = "",
 
 ) {
   companion object {
 
-    fun from(personEntity: PersonEntity): CanonicalNationality = CanonicalNationality(
-      nationality1 = personEntity.nationality,
-    )
+    fun from(personEntity: PersonEntity): List<CanonicalNationality>? = personEntity.nationality?.let { listOf(CanonicalNationality(it)) }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/canonical/CanonicalRecord.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/canonical/CanonicalRecord.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.personrecord.api.model.canonical
 
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.PersonKeyEntity
 
 data class CanonicalRecord(
@@ -14,16 +16,19 @@ data class CanonicalRecord(
   val religion: String? = "",
   val ethnicity: String? = "",
   val aliases: List<CanonicalAlias> = emptyList(),
-  val nationalities: List<CanonicalNationality> = emptyList(),
+  @ArraySchema(
+    schema = Schema(description = "List of nationality codes", example = "[{\"nationalityCode\": \"UK\"}, {\"nationalityCode\": \"IE\"}]"),
+  )
+  var nationalities: List<CanonicalNationality> = emptyList(),
   val addresses: List<CanonicalAddress> = emptyList(),
   val references: List<CanonicalReference> = emptyList(),
-  val identifiers: Identifiers,
+  val identifiers: CanonicalIdentifiers,
 
 ) {
   companion object {
     fun from(personKey: PersonKeyEntity): CanonicalRecord {
       val latestPerson = personKey.personEntities.sortedByDescending { it.lastModified }.first()
-      val additonalIdentifiers = Identifiers.from(personKey)
+      val additonalIdentifiers = CanonicalIdentifiers.from(personKey)
       return CanonicalRecord(
         id = personKey.personId.toString(),
         firstName = latestPerson.firstName,
@@ -38,7 +43,7 @@ data class CanonicalRecord(
         aliases = CanonicalAlias.fromPseudonymEntityList(latestPerson.pseudonyms),
         addresses = CanonicalAddress.fromAddressEntityList(latestPerson.addresses),
         references = CanonicalReference.fromReferenceEntityList(latestPerson.references),
-        nationalities = listOf(CanonicalNationality.from(latestPerson)),
+        nationalities = CanonicalNationality.from(latestPerson) ?: emptyList(),
         identifiers = additonalIdentifiers,
 
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/canonical/CanonicalRecord.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/canonical/CanonicalRecord.kt
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.PersonKeyEntity
 
 data class CanonicalRecord(
-  val id: String? = "",
+  val personUUID: String? = "",
   val firstName: String? = "",
   val middleNames: String? = "",
   val lastName: String? = "",
@@ -30,7 +30,7 @@ data class CanonicalRecord(
       val latestPerson = personKey.personEntities.sortedByDescending { it.lastModified }.first()
       val additonalIdentifiers = CanonicalIdentifiers.from(personKey)
       return CanonicalRecord(
-        id = personKey.personId.toString(),
+        personUUID = personKey.personId.toString(),
         firstName = latestPerson.firstName,
         middleNames = latestPerson.middleNames,
         lastName = latestPerson.lastName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/canonical/CanonicalRecord.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/canonical/CanonicalRecord.kt
@@ -8,36 +8,28 @@ data class CanonicalRecord(
   val middleNames: String? = "",
   val lastName: String? = "",
   val dateOfBirth: String? = "",
-  val crn: String? = "",
-  var prisonNumber: String? = "",
-  var defendantId: String? = "",
   val title: String? = "",
   val masterDefendantId: String? = "",
   val sex: String? = "",
   val religion: String? = "",
   val ethnicity: String? = "",
-  val cid: String? = "",
   val aliases: List<CanonicalAlias> = emptyList(),
   val nationalities: List<CanonicalNationality> = emptyList(),
   val addresses: List<CanonicalAddress> = emptyList(),
   val references: List<CanonicalReference> = emptyList(),
-  val additionalIdentifiers: CanonicalAdditionalIdentifiers,
+  val identifiers: Identifiers,
 
 ) {
   companion object {
     fun from(personKey: PersonKeyEntity): CanonicalRecord {
       val latestPerson = personKey.personEntities.sortedByDescending { it.lastModified }.first()
-      val additonalIdentifiers = CanonicalAdditionalIdentifiers.from(personKey)
+      val additonalIdentifiers = Identifiers.from(personKey)
       return CanonicalRecord(
         id = personKey.personId.toString(),
         firstName = latestPerson.firstName,
         middleNames = latestPerson.middleNames,
-        cid = latestPerson.cId,
         lastName = latestPerson.lastName,
         dateOfBirth = latestPerson.dateOfBirth?.toString() ?: "",
-        crn = latestPerson.crn,
-        prisonNumber = latestPerson.prisonNumber,
-        defendantId = latestPerson.defendantId,
         title = latestPerson.title,
         masterDefendantId = latestPerson.masterDefendantId,
         sex = latestPerson.sex,
@@ -47,7 +39,7 @@ data class CanonicalRecord(
         addresses = CanonicalAddress.fromAddressEntityList(latestPerson.addresses),
         references = CanonicalReference.fromReferenceEntityList(latestPerson.references),
         nationalities = listOf(CanonicalNationality.from(latestPerson)),
-        additionalIdentifiers = additonalIdentifiers,
+        identifiers = additonalIdentifiers,
 
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/canonical/Identifiers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/canonical/Identifiers.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.personrecord.api.model.canonical
 
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.PersonKeyEntity
 
-data class CanonicalAdditionalIdentifiers(
+data class Identifiers(
   val crns: List<String?> = emptyList(),
   val defendantIds: List<String?> = emptyList(),
   val prisonNumbers: List<String?> = emptyList(),
@@ -10,7 +10,7 @@ data class CanonicalAdditionalIdentifiers(
 ) {
   companion object {
 
-    fun from(personKeyEntity: PersonKeyEntity): CanonicalAdditionalIdentifiers = CanonicalAdditionalIdentifiers(
+    fun from(personKeyEntity: PersonKeyEntity): Identifiers = Identifiers(
       crns = personKeyEntity.personEntities.mapNotNull { it.crn },
       defendantIds = personKeyEntity.personEntities.mapNotNull { it.defendantId },
       prisonNumbers = personKeyEntity.personEntities.mapNotNull { it.prisonNumber },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/SearchIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/SearchIntTest.kt
@@ -330,14 +330,10 @@ class SearchIntTest : WebTestBase() {
     assertThat(responseBody.lastName).isEqualTo(person.lastName)
     assertThat(responseBody.dateOfBirth).isEqualTo(person.dateOfBirth.toString())
     assertThat(responseBody.title).isEqualTo(person.title)
-    assertThat(responseBody.crn).isEqualTo(person.crn)
-    assertThat(responseBody.prisonNumber).isEqualTo(person.prisonNumber)
     assertThat(responseBody.ethnicity).isEqualTo(person.ethnicity)
     assertThat(responseBody.nationalities).isEqualTo(listOf(canonicalNationality))
     assertThat(responseBody.sex).isEqualTo(person.sex)
     assertThat(responseBody.religion).isEqualTo(person.religion)
-    assertThat(responseBody.cid).isEqualTo(person.cId)
-    assertThat(responseBody.defendantId).isEqualTo(person.defendantId)
     assertThat(responseBody.masterDefendantId).isEqualTo(person.masterDefendantId)
     assertThat(responseBody.aliases).isEqualTo(listOf(canonicalAlias))
     assertThat(responseBody.references).isEqualTo(listOf(canonicalReference))
@@ -427,10 +423,10 @@ class SearchIntTest : WebTestBase() {
       .returnResult()
       .responseBody!!
 
-    assertThat(responseBody.additionalIdentifiers.crns).isEqualTo(listOf(personOne.crn, personTwo.crn))
-    assertThat(responseBody.additionalIdentifiers.defendantIds).isEqualTo(listOf(personOne.defendantId, personTwo.defendantId))
-    assertThat(responseBody.additionalIdentifiers.prisonNumbers).isEqualTo(listOf(personOne.prisonNumber, personTwo.prisonNumber))
-    assertThat(responseBody.additionalIdentifiers.cids).isEqualTo(listOf(personOne.cId, personTwo.cId))
+    assertThat(responseBody.identifiers.crns).isEqualTo(listOf(personOne.crn, personTwo.crn))
+    assertThat(responseBody.identifiers.defendantIds).isEqualTo(listOf(personOne.defendantId, personTwo.defendantId))
+    assertThat(responseBody.identifiers.prisonNumbers).isEqualTo(listOf(personOne.prisonNumber, personTwo.prisonNumber))
+    assertThat(responseBody.identifiers.cids).isEqualTo(listOf(personOne.cId, personTwo.cId))
   }
 
   @Test
@@ -463,10 +459,10 @@ class SearchIntTest : WebTestBase() {
       .returnResult()
       .responseBody!!
 
-    assertThat(responseBody.additionalIdentifiers.crns).isNotNull()
-    assertThat(responseBody.additionalIdentifiers.prisonNumbers).isNotNull()
-    assertThat(responseBody.additionalIdentifiers.defendantIds).isNotNull()
-    assertThat(responseBody.additionalIdentifiers.cids).isNotNull()
+    assertThat(responseBody.identifiers.crns).isNotNull()
+    assertThat(responseBody.identifiers.prisonNumbers).isNotNull()
+    assertThat(responseBody.identifiers.defendantIds).isNotNull()
+    assertThat(responseBody.identifiers.cids).isNotNull()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/SearchIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/SearchIntTest.kt
@@ -324,7 +324,7 @@ class SearchIntTest : WebTestBase() {
       .returnResult()
       .responseBody!!
 
-    assertThat(responseBody.id).isEqualTo(person.personKey?.personId.toString())
+    assertThat(responseBody.personUUID).isEqualTo(person.personKey?.personId.toString())
     assertThat(responseBody.firstName).isEqualTo(person.firstName)
     assertThat(responseBody.middleNames).isEqualTo(person.middleNames)
     assertThat(responseBody.lastName).isEqualTo(person.lastName)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/SearchIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/SearchIntTest.kt
@@ -288,7 +288,7 @@ class SearchIntTest : WebTestBase() {
 
     val canonicalAlias = CanonicalAlias(firstName = firstName, lastName = lastName, middleNames = middleNames, title = title)
     val canonicalReference = CanonicalReference(IdentifierType.PNC, identifierValue = pnc)
-    val canonicalNationality = CanonicalNationality(nationality)
+    val canonicalNationality = listOf(CanonicalNationality(nationalityCode = nationality))
     val canonicalAddress = CanonicalAddress(noFixedAbode = noFixAbode.toString(), startDate = startDate.toString(), endDate = endDate.toString(), postcode = postcode, buildingName = buildingName, buildingNumber = buildingNumber, thoroughfareName = thoroughfareName, dependentLocality = dependentLocality, postTown = postTown)
 
     val person = createPersonWithNewKey(
@@ -331,7 +331,7 @@ class SearchIntTest : WebTestBase() {
     assertThat(responseBody.dateOfBirth).isEqualTo(person.dateOfBirth.toString())
     assertThat(responseBody.title).isEqualTo(person.title)
     assertThat(responseBody.ethnicity).isEqualTo(person.ethnicity)
-    assertThat(responseBody.nationalities).isEqualTo(listOf(canonicalNationality))
+    assertThat(responseBody.nationalities).isEqualTo(canonicalNationality)
     assertThat(responseBody.sex).isEqualTo(person.sex)
     assertThat(responseBody.religion).isEqualTo(person.religion)
     assertThat(responseBody.masterDefendantId).isEqualTo(person.masterDefendantId)


### PR DESCRIPTION
"CPR-508-update-canonical-fields changed additionalidentifiers to identifiers and removed crn,cid,defendantId and prisonnumber from top level of the api"