### PR TITLE
CPP-634 code should now handle the case where the UUID does not retur…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/SearchController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/SearchController.kt
@@ -115,7 +115,7 @@ class SearchController(
   }
 
   private fun buildCanonicalRecord(personKeyEntity: PersonKeyEntity?, uuid: UUID): CanonicalRecord = when {
-    personKeyEntity != PersonEntity.empty -> CanonicalRecord.from(personKeyEntity)
+    personKeyEntity?.personEntities?.isNotEmpty() == true -> CanonicalRecord.from(personKeyEntity)
     else -> throw PersonKeyNotFoundException(uuid)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/canonical/CanonicalRecord.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/canonical/CanonicalRecord.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.personrecord.api.model.canonical
 
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
-import uk.gov.justice.digital.hmpps.personrecord.api.controller.exceptions.PersonKeyNotFoundException
 import uk.gov.justice.digital.hmpps.personrecord.api.model.canonical.CanonicalIdentifierType.CRN
 import uk.gov.justice.digital.hmpps.personrecord.api.model.canonical.CanonicalIdentifierType.C_ID
 import uk.gov.justice.digital.hmpps.personrecord.api.model.canonical.CanonicalIdentifierType.DEFENDANT_ID
@@ -48,27 +47,22 @@ data class CanonicalRecord(
     fun from(personKey: PersonKeyEntity): CanonicalRecord {
       val personList = personKey.personEntities.sortedByDescending { it.lastModified }
 
-      when (personList.isNullOrEmpty()) {
-        true -> throw personKey.personId?.let { PersonKeyNotFoundException(it) }!!
-        else -> {
-          val latestPerson = personList.first()
-          return CanonicalRecord(
-            cprUUID = personKey.personId.toString(),
-            firstName = latestPerson.firstName,
-            middleNames = latestPerson.middleNames,
-            lastName = latestPerson.lastName,
-            dateOfBirth = latestPerson.dateOfBirth?.toString() ?: "",
-            title = latestPerson.title,
-            sex = latestPerson.sex,
-            religion = latestPerson.religion,
-            ethnicity = latestPerson.ethnicity,
-            aliases = CanonicalAlias.fromPseudonymEntityList(latestPerson.pseudonyms),
-            addresses = CanonicalAddress.fromAddressEntityList(latestPerson.addresses),
-            identifiers = getCanonicalIdentifiers(personKey.personEntities) + CanonicalIdentifier.fromReferenceEntityList(latestPerson.references),
-            nationalities = CanonicalNationality.from(latestPerson),
-          )
-        }
-      }
+      val latestPerson = personList.first()
+      return CanonicalRecord(
+        cprUUID = personKey.personId.toString(),
+        firstName = latestPerson.firstName,
+        middleNames = latestPerson.middleNames,
+        lastName = latestPerson.lastName,
+        dateOfBirth = latestPerson.dateOfBirth?.toString() ?: "",
+        title = latestPerson.title,
+        sex = latestPerson.sex,
+        religion = latestPerson.religion,
+        ethnicity = latestPerson.ethnicity,
+        aliases = CanonicalAlias.fromPseudonymEntityList(latestPerson.pseudonyms),
+        addresses = CanonicalAddress.fromAddressEntityList(latestPerson.addresses),
+        identifiers = getCanonicalIdentifiers(personKey.personEntities) + CanonicalIdentifier.fromReferenceEntityList(latestPerson.references),
+        nationalities = CanonicalNationality.from(latestPerson),
+      )
     }
 
     private fun getCanonicalIdentifiers(personEntities: List<PersonEntity>): MutableList<CanonicalIdentifier> = listOf(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/canonical/CanonicalRecord.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/canonical/CanonicalRecord.kt
@@ -48,7 +48,7 @@ data class CanonicalRecord(
     fun from(personKey: PersonKeyEntity): CanonicalRecord {
       val personList = personKey.personEntities.sortedByDescending { it.lastModified }
 
-      when(personList.isNullOrEmpty()) {
+      when (personList.isNullOrEmpty()) {
         true -> throw personKey.personId?.let { PersonKeyNotFoundException(it) }!!
         else -> {
           val latestPerson = personList.first()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/SearchIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/SearchIntTest.kt
@@ -570,7 +570,7 @@ class SearchIntTest : WebTestBase() {
   }
 
   @Test
-  fun `should return bad request with userMessage to show that the UUID is not found`() {
+  fun `should return not found 404 with userMessage to show that the UUID is not found`() {
     val randomUUId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
     val expectedErrorMessage = "Not found: $randomUUId"
     webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/SearchIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/SearchIntTest.kt
@@ -577,8 +577,34 @@ class SearchIntTest : WebTestBase() {
       .uri(searchForPerson(randomUUId))
       .authorised(listOf(SEARCH_API_READ_ONLY))
       .exchange()
-      .expectBody().jsonPath("userMessage")
+      .expectStatus()
+      .isNotFound
+      .expectBody()
+      .jsonPath("userMessage")
       .isEqualTo(expectedErrorMessage)
+  }
+
+  @Test
+  fun `should return Access Denied 403 when role is wrong`() {
+    val expectedErrorMessage = "Forbidden: Access Denied"
+    webTestClient.get()
+      .uri(searchForPerson("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+      .authorised(listOf("UNSUPPORTED-ROLE"))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+      .expectBody()
+      .jsonPath("userMessage")
+      .isEqualTo(expectedErrorMessage)
+  }
+
+  @Test
+  fun `should return UNAUTHORIZED 401 when role is not set`() {
+    webTestClient.get()
+      .uri(searchForPerson("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
   }
 
   companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/SearchIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/SearchIntTest.kt
@@ -569,6 +569,18 @@ class SearchIntTest : WebTestBase() {
       .isBadRequest
   }
 
+  @Test
+  fun `should return bad request with userMessage to show that the UUID is not found`() {
+    val randomUUId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    val expectedErrorMessage = "Not found: $randomUUId"
+    webTestClient.get()
+      .uri(searchForPerson(randomUUId))
+      .authorised(listOf(SEARCH_API_READ_ONLY))
+      .exchange()
+      .expectBody().jsonPath("userMessage")
+      .isEqualTo(expectedErrorMessage)
+  }
+
   companion object {
 
     private fun searchForPerson(uuid: String) = "/search/person/$uuid"


### PR DESCRIPTION
cases covererd:
wrong role - return 403
unauthorised - return 401
UUID is invalid -> returns 404 - BAD_REQUEST, with correct message
UUID is valid - does not exist in the db - results in empty list -> returns 400, NOT_FOUND, with correct message
