### PR TITLE
Tidy up wiremock

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/IntegrationTestBase.kt
@@ -183,14 +183,10 @@ class IntegrationTestBase {
     )
   }
 
-  internal fun stubDeletePersonMatch(scenario: String = BASE_SCENARIO, currentScenarioState: String = STARTED, nextScenarioState: String = STARTED, status: Int = 200, body: String = "{}") {
+  internal fun stubDeletePersonMatch(status: Int = 200) {
     stubDeleteRequest(
-      scenario,
-      currentScenarioState,
-      nextScenarioState,
-      "/person",
+      url = "/person",
       status = status,
-      body = body,
     )
   }
 
@@ -239,7 +235,7 @@ class IntegrationTestBase {
     )
   }
 
-  internal fun stubDeleteRequest(scenarioName: String? = BASE_SCENARIO, currentScenarioState: String? = STARTED, nextScenarioState: String? = STARTED, url: String, body: String, status: Int = 200) {
+  internal fun stubDeleteRequest(scenarioName: String? = BASE_SCENARIO, currentScenarioState: String? = STARTED, nextScenarioState: String? = STARTED, url: String, body: String = "{}", status: Int = 200) {
     wiremock.stubFor(
       WireMock.delete(url)
         .inScenario(scenarioName)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/MessagingMultiNodeTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/MessagingMultiNodeTestBase.kt
@@ -237,7 +237,7 @@ abstract class MessagingMultiNodeTestBase : IntegrationTestBase() {
 
   private fun stubSingleProbationResponse(probationCase: ApiResponseSetup, scenarioName: String, currentScenarioState: String, nextScenarioState: String) = stubGetRequest(scenarioName, currentScenarioState, nextScenarioState, "/probation-cases/${probationCase.crn}", probationCaseResponse(probationCase))
 
-  fun stub500Response(url: String, nextScenarioState: String = "Next request will succeed", scenarioName: String, currentScenarioState: String = STARTED) = stubGetRequest(scenarioName, currentScenarioState, nextScenarioState, url, body = "", status = 500)
+  fun stub500Response(url: String, nextScenarioState: String = "Next request will succeed", scenarioName: String? = BASE_SCENARIO, currentScenarioState: String = STARTED) = stubGetRequest(scenarioName, currentScenarioState, nextScenarioState, url, body = "", status = 500)
 
   fun stubPrisonResponse(
     apiResponseSetup: ApiResponseSetup,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationUnmergeEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationUnmergeEventListenerIntTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.personrecord.message.listeners.probation
 
-import com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.untilAsserted
@@ -418,12 +417,12 @@ class ProbationUnmergeEventListenerIntTest : MessagingMultiNodeTestBase() {
   fun `should log when message processing fails`() {
     val reactivatedCrn = randomCrn()
     val unmergedCrn = randomCrn()
-    stub500Response(probationUrl(unmergedCrn), STARTED, "failure")
-    stub500Response(probationUrl(unmergedCrn), STARTED, "failure")
-    stub500Response(probationUrl(unmergedCrn), STARTED, "failure")
-    stub500Response(probationUrl(reactivatedCrn), STARTED, "failure")
-    stub500Response(probationUrl(reactivatedCrn), STARTED, "failure")
-    stub500Response(probationUrl(reactivatedCrn), STARTED, "failure")
+    stub500Response(probationUrl(unmergedCrn), "next request will fail", "failure")
+    stub500Response(probationUrl(unmergedCrn), "next request will fail", "failure", "next request will fail")
+    stub500Response(probationUrl(unmergedCrn), "next request will fail", "failure", "next request will fail")
+    stub500Response(probationUrl(reactivatedCrn), "next request will fail", "failure", "next request will fail")
+    stub500Response(probationUrl(reactivatedCrn), "next request will fail", "failure", "next request will fail")
+    stub500Response(probationUrl(reactivatedCrn), "next request will fail", "failure", "next request will fail")
 
     val messageId = publishDomainEvent(
       OFFENDER_UNMERGED,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/seeding/UpdateFromProbationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/seeding/UpdateFromProbationIntTest.kt
@@ -20,7 +20,6 @@ class UpdateFromProbationIntTest : WebTestBase() {
 
   @Test
   fun `update from probation`() {
-    val scenarioName = "update"
     val crnOne: String = randomCrn()
     val crnTwo: String = randomCrn()
     val crnThree: String = randomCrn()
@@ -38,10 +37,10 @@ class UpdateFromProbationIntTest : WebTestBase() {
         crn = crnSeven,
       ),
     )
-    stubResponse(crnOne, "POPOne", crnTwo, "POPTwo", 0, scenarioName, STARTED)
-    stubResponse(crnThree, "POPThree", crnFour, "POPFour", 1, scenarioName, STARTED)
-    stubResponse(crnFive, "POPFive", crnSix, "POPSix", 2, scenarioName, STARTED)
-    stubSingleResponse(crnSeven, "POPSeven", 3, scenarioName)
+    stubResponse(crnOne, "POPOne", crnTwo, "POPTwo", 0)
+    stubResponse(crnThree, "POPThree", crnFour, "POPFour", 1)
+    stubResponse(crnFive, "POPFive", crnSix, "POPSix", 2)
+    stubSingleResponse(crnSeven, "POPSeven", 3)
 
     webTestClient.post()
       .uri("/updatefromprobation")
@@ -79,7 +78,6 @@ class UpdateFromProbationIntTest : WebTestBase() {
 
   @Test
   fun `start on page 2`() {
-    val scenarioName = "update"
     val crnOne: String = randomCrn()
     val crnTwo: String = randomCrn()
     val crnThree: String = randomCrn()
@@ -88,8 +86,8 @@ class UpdateFromProbationIntTest : WebTestBase() {
     val crnSix: String = randomCrn()
     val crnSeven: String = randomCrn()
 
-    stubResponse(crnFive, "POPFive", crnSix, "POPSix", 2, scenarioName, STARTED)
-    stubSingleResponse(crnSeven, "POPSeven", 3, scenarioName)
+    stubResponse(crnFive, "POPFive", crnSix, "POPSix", 2)
+    stubSingleResponse(crnSeven, "POPSeven", 3)
 
     webTestClient.post()
       .uri("/updatefromprobation?startPage=2")
@@ -113,16 +111,16 @@ class UpdateFromProbationIntTest : WebTestBase() {
     assertThat(popSeven.sentenceInfo[0].sentenceDate).isEqualTo(newSentenceDate)
   }
 
-  private fun stubResponse(firstCrn: String, firstPrefix: String, secondCrn: String, secondPrefix: String, page: Int, scenarioName: String, scenarioState: String, totalPages: Int = 4) = stubGetRequest(
+  private fun stubResponse(firstCrn: String, firstPrefix: String, secondCrn: String, secondPrefix: String, page: Int) = stubGetRequest(
     url = "/all-probation-cases?size=2&page=$page&sort=id%2Casc",
-    scenarioName = scenarioName,
-    currentScenarioState = scenarioState,
-    body = allProbationCasesResponse(firstCrn, firstPrefix, secondCrn, secondPrefix, totalPages),
+    scenarioName = "update",
+    currentScenarioState = STARTED,
+    body = allProbationCasesResponse(firstCrn, firstPrefix, secondCrn, secondPrefix, 4),
   )
 
-  private fun stubSingleResponse(firstCrn: String, firstPrefix: String, page: Int, scenarioName: String) = stubGetRequest(
+  private fun stubSingleResponse(firstCrn: String, firstPrefix: String, page: Int) = stubGetRequest(
     url = "/all-probation-cases?size=2&page=$page&sort=id%2Casc",
-    scenarioName = scenarioName,
+    scenarioName = "update",
     currentScenarioState = STARTED,
     body = allProbationCasesSingleResponse(firstCrn, firstPrefix),
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/seeding/UpdateFromProbationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/seeding/UpdateFromProbationIntTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.personrecord.seeding
 
-import com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.personrecord.config.WebTestBase
@@ -113,15 +112,11 @@ class UpdateFromProbationIntTest : WebTestBase() {
 
   private fun stubResponse(firstCrn: String, firstPrefix: String, secondCrn: String, secondPrefix: String, page: Int) = stubGetRequest(
     url = "/all-probation-cases?size=2&page=$page&sort=id%2Casc",
-    scenarioName = "update",
-    currentScenarioState = STARTED,
     body = allProbationCasesResponse(firstCrn, firstPrefix, secondCrn, secondPrefix, 4),
   )
 
   private fun stubSingleResponse(firstCrn: String, firstPrefix: String, page: Int) = stubGetRequest(
     url = "/all-probation-cases?size=2&page=$page&sort=id%2Casc",
-    scenarioName = "update",
-    currentScenarioState = STARTED,
     body = allProbationCasesSingleResponse(firstCrn, firstPrefix),
   )
 }


### PR DESCRIPTION
The simpler we can make stubbing, the easier the tests will be to understand.
I also think we should ideally not have any dependencies on wiremock outside the base classes