### PR TITLE
FIX: delay startup by 5 mins to ensure that hmpps-person-match has started

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -26,6 +26,8 @@ generic-service:
 
   scheduledDowntime:
     enabled: true
+    # Start at 6:35am UTC Monday-Friday - 5 minutes after hmpps-person-match
+    startup: '35 6 * * 1-5'
 
 generic-prometheus-alerts:
   businessHoursOnly: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -17,6 +17,8 @@ generic-service:
 
   scheduledDowntime:
     enabled: true
+    # Start at 6:35am UTC Monday-Friday - 5 minutes after hmpps-person-match
+    startup: '35 6 * * 1-5'
 
 generic-prometheus-alerts:
   businessHoursOnly: true


### PR DESCRIPTION
This is to avoid alerts when hmpps-person-record comes up before hmpps-person-match and starts consuming messages which have built up overnight

https://github.com/ministryofjustice/hmpps-helm-charts/blob/main/charts/generic-service/values.yaml#L250