### PR TITLE
CPR-710 fix flaky test

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/EventLogRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/EventLogRepository.kt
@@ -4,9 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.EventLogEntity
 import uk.gov.justice.digital.hmpps.personrecord.service.eventlog.CPRLogEvents
+import java.util.UUID
 
 @Repository
 interface EventLogRepository : JpaRepository<EventLogEntity, Long> {
 
   fun findAllByEventTypeAndSourceSystemIdOrderByEventTimestampDesc(eventType: CPRLogEvents, sourceSystemId: String): List<EventLogEntity>?
+  fun findAllByEventTypeAndUuidOrderByEventTimestampDesc(eventType: CPRLogEvents, cluster: UUID): List<EventLogEntity>?
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/IntegrationTestBase.kt
@@ -147,6 +147,17 @@ class IntegrationTestBase {
     }, timeout)
   }
 
+  internal fun checkEventLogByUUID(
+    cluster: UUID,
+    event: CPRLogEvents,
+    timeout: Long = 3,
+    matchingEvents: (logEvents: List<EventLogEntity>) -> Unit,
+  ) {
+    awaitAssert(function = {
+      matchingEvents(eventLogRepository.findAllByEventTypeAndUuidOrderByEventTimestampDesc(event, cluster) ?: emptyList())
+    }, timeout)
+  }
+
   private fun awaitAssert(function: () -> Unit, timeout: Long) = await atMost (Duration.ofSeconds(timeout)) untilAsserted function
 
   internal fun awaitAssert(function: () -> Unit) = awaitAssert(function = function, timeout = 3)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/ReclusterServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/ReclusterServiceIntTest.kt
@@ -1147,8 +1147,7 @@ class ReclusterServiceIntTest : MessagingMultiNodeTestBase() {
       cluster2.assertMergedTo(cluster1)
 
       cluster2.checkReclusterMergeTelemetry(cluster1)
-
-      checkEventLog(personC.crn!!, CPRLogEvents.CPR_RECLUSTER_UUID_MERGED, timeout = 6) { eventLogs ->
+      checkEventLogByUUID(cluster2.personUUID!!, CPRLogEvents.CPR_RECLUSTER_UUID_MERGED, timeout = 6) { eventLogs ->
         assertThat(eventLogs).hasSize(1)
         val eventLog = eventLogs.first()
         assertThat(eventLog.uuid).isEqualTo(cluster2.personUUID)


### PR DESCRIPTION
https://github.com/ministryofjustice/hmpps-person-record/blob/a10a7a8909aa4039f2d37f15b0bd2db5c5171693/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/message/recluster/ReclusterService.kt#L78

The theory is that `.first()` can be either record in the cluster although it is usually personC

An alternative fix would be to have the clusters be 3 records and 1 record and have 1 merge into the 3. Then `.first()` can only be one record