### PR TITLE
CPR-393 remove bean provided by kotlin-lib

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/SecurityConfiguration.kt
@@ -2,34 +2,10 @@ package uk.gov.justice.digital.hmpps.personrecord.config
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import uk.gov.justice.hmpps.kotlin.auth.dsl.ResourceServerConfigurationCustomizer
 
 @Configuration
 class SecurityConfiguration {
-
-  @Bean
-  fun authorizedClientManager(
-    clientRegistrationRepository: ClientRegistrationRepository?,
-    clientService: OAuth2AuthorizedClientService,
-  ): OAuth2AuthorizedClientManager {
-    val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder()
-      .clientCredentials()
-      .build()
-
-    val authorizedClientManager = AuthorizedClientServiceOAuth2AuthorizedClientManager(
-      clientRegistrationRepository,
-      clientService,
-    )
-
-    authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider)
-
-    return authorizedClientManager
-  }
 
   @Bean
   fun resourceServerCustomizer() = ResourceServerConfigurationCustomizer {


### PR DESCRIPTION
Uses this instead:
https://github.com/ministryofjustice/hmpps-kotlin-lib/blob/main/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/HmppsWebClientConfiguration.kt#L61