### PR TITLE
CPR-640 retry db calls every 200ms

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/message/CreateUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/message/CreateUpdateService.kt
@@ -23,7 +23,7 @@ class CreateUpdateService(
 ) {
 
   @Retryable(
-    backoff = Backoff(random = true, delay = 1000, maxDelay = 2000, multiplier = 1.5),
+    backoff = Backoff(delay = 200),
     retryFor = [
       OptimisticLockException::class,
       DataIntegrityViolationException::class,


### PR DESCRIPTION
This should simply speed up processing as the delay between retries is shorted