### PR TITLE
CPR-640 shows that retrying is actually done by the redrive policy

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/processors/prison/PrisonEventProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/processors/prison/PrisonEventProcessor.kt
@@ -1,6 +1,12 @@
 package uk.gov.justice.digital.hmpps.personrecord.message.processors.prison
 
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClientRequestException
+import org.springframework.web.reactive.function.client.WebClientResponseException.BadGateway
+import org.springframework.web.reactive.function.client.WebClientResponseException.InternalServerError
+import org.springframework.web.reactive.function.client.WebClientResponseException.ServiceUnavailable
 import uk.gov.justice.digital.hmpps.personrecord.client.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.DomainEvent
 import uk.gov.justice.digital.hmpps.personrecord.jpa.repository.PersonRepository
@@ -14,6 +20,15 @@ class PrisonEventProcessor(
   private val prisonerSearchClient: PrisonerSearchClient,
 ) {
 
+  @Retryable(
+    backoff = Backoff(delay = 200, random = true, multiplier = 3.0),
+    retryFor = [
+      InternalServerError::class,
+      BadGateway::class,
+      ServiceUnavailable::class,
+      WebClientRequestException::class,
+    ],
+  )
   fun processEvent(domainEvent: DomainEvent) {
     val prisonNumber = domainEvent.additionalInformation?.prisonNumber!!
     prisonerSearchClient.getPrisoner(prisonNumber)?.let {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/processors/prison/PrisonMergeEventProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/processors/prison/PrisonMergeEventProcessor.kt
@@ -1,6 +1,12 @@
 package uk.gov.justice.digital.hmpps.personrecord.message.processors.prison
 
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClientRequestException
+import org.springframework.web.reactive.function.client.WebClientResponseException.BadGateway
+import org.springframework.web.reactive.function.client.WebClientResponseException.InternalServerError
+import org.springframework.web.reactive.function.client.WebClientResponseException.ServiceUnavailable
 import uk.gov.justice.digital.hmpps.personrecord.client.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.DomainEvent
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.PersonEntity
@@ -17,6 +23,15 @@ class PrisonMergeEventProcessor(
   private val createUpdateService: CreateUpdateService,
 ) {
 
+  @Retryable(
+    backoff = Backoff(delay = 200, random = true, multiplier = 3.0),
+    retryFor = [
+      InternalServerError::class,
+      BadGateway::class,
+      ServiceUnavailable::class,
+      WebClientRequestException::class,
+    ],
+  )
   fun processEvent(domainEvent: DomainEvent) {
     prisonerSearchClient.getPrisoner(domainEvent.additionalInformation?.prisonNumber!!)?.let {
       val from: PersonEntity? =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/processors/probation/ProbationEventProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/processors/probation/ProbationEventProcessor.kt
@@ -1,6 +1,12 @@
 package uk.gov.justice.digital.hmpps.personrecord.message.processors.probation
 
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClientRequestException
+import org.springframework.web.reactive.function.client.WebClientResponseException.BadGateway
+import org.springframework.web.reactive.function.client.WebClientResponseException.InternalServerError
+import org.springframework.web.reactive.function.client.WebClientResponseException.ServiceUnavailable
 import uk.gov.justice.digital.hmpps.personrecord.client.CorePersonRecordAndDeliusClient
 import uk.gov.justice.digital.hmpps.personrecord.jpa.repository.PersonRepository
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Person
@@ -13,6 +19,15 @@ class ProbationEventProcessor(
   private val corePersonRecordAndDeliusClient: CorePersonRecordAndDeliusClient,
 ) {
 
+  @Retryable(
+    backoff = Backoff(delay = 200, random = true, multiplier = 3.0),
+    retryFor = [
+      InternalServerError::class,
+      BadGateway::class,
+      ServiceUnavailable::class,
+      WebClientRequestException::class,
+    ],
+  )
   fun processEvent(crn: String) {
     corePersonRecordAndDeliusClient.getProbationCase(crn).let {
       createUpdateService.processPerson(Person.from(it)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/processors/probation/ProbationMergeEventProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/processors/probation/ProbationMergeEventProcessor.kt
@@ -1,6 +1,12 @@
 package uk.gov.justice.digital.hmpps.personrecord.message.processors.probation
 
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClientRequestException
+import org.springframework.web.reactive.function.client.WebClientResponseException.BadGateway
+import org.springframework.web.reactive.function.client.WebClientResponseException.InternalServerError
+import org.springframework.web.reactive.function.client.WebClientResponseException.ServiceUnavailable
 import uk.gov.justice.digital.hmpps.personrecord.client.CorePersonRecordAndDeliusClient
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.DomainEvent
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.PersonEntity
@@ -17,6 +23,15 @@ class ProbationMergeEventProcessor(
   private val corePersonRecordAndDeliusClient: CorePersonRecordAndDeliusClient,
 ) {
 
+  @Retryable(
+    backoff = Backoff(delay = 200, random = true, multiplier = 3.0),
+    retryFor = [
+      InternalServerError::class,
+      BadGateway::class,
+      ServiceUnavailable::class,
+      WebClientRequestException::class,
+    ],
+  )
   fun processEvent(mergeDomainEvent: DomainEvent) {
     val toCrn = mergeDomainEvent.additionalInformation?.targetCrn!!
     val fromCrn = mergeDomainEvent.additionalInformation.sourceCrn!!

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/message/CreateUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/message/CreateUpdateService.kt
@@ -10,10 +10,6 @@ import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Isolation.REPEATABLE_READ
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.web.reactive.function.client.WebClientRequestException
-import org.springframework.web.reactive.function.client.WebClientResponseException.BadGateway
-import org.springframework.web.reactive.function.client.WebClientResponseException.InternalServerError
-import org.springframework.web.reactive.function.client.WebClientResponseException.ServiceUnavailable
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.PersonEntity
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.PersonEntity.Companion.exists
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Person
@@ -32,10 +28,6 @@ class CreateUpdateService(
       OptimisticLockException::class,
       DataIntegrityViolationException::class,
       CannotAcquireLockException::class,
-      InternalServerError::class,
-      BadGateway::class,
-      ServiceUnavailable::class,
-      WebClientRequestException::class,
     ],
   )
   @Transactional(isolation = REPEATABLE_READ)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListenerIntTest.kt
@@ -277,7 +277,7 @@ class ProbationEventListenerIntTest : MessagingMultiNodeTestBase() {
     fun `test multiple requests to probation single record process successfully`() {
       val pnc = randomPnc()
       val crn = randomCrn()
-      blitz(30, 6) {
+      blitz(30, 2) {
         probationDomainEventAndResponseSetup(OFFENDER_PERSONAL_DETAILS_UPDATED, ApiResponseSetup(crn = crn, pnc = pnc))
       }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -46,26 +46,31 @@ hmpps.sqs:
       dlqName: cpr_delius_offender_events_queue_dlq
       subscribeTopicId: domainevents
       subscribeFilter: '{"eventType":[ "probation-case.engagement.created", "probation-case.address.created", "probation-case.address.updated", "probation-case.address.deleted","probation-case.personal-details.updated", "OFFENDER_ALIAS_CHANGED", "probation-case.engagement.recovered" ] }'
+      dlqMaxReceiveCount: 1
     cprdeliusmergeeventsqueue:
       queueName: cpr_delius_merge_events_queue
       dlqName: cpr_delius_merge_events_queue_dlq
       subscribeTopicId: domainevents
       subscribeFilter: '{"eventType":[ "probation-case.merge.completed", "probation-case.unmerge.completed"] }'
+      dlqMaxReceiveCount: 1
     cprdeliusdeleteeventsqueue:
       queueName: cpr_delius_delete_events_queue
       dlqName: cpr_delius_delete_events_queue_dlq
       subscribeTopicId: domainevents
       subscribeFilter: '{"eventType":[ "probation-case.deleted.gdpr", "probation-case.engagement.deleted" ] }'
+      dlqMaxReceiveCount: 1
     cprnomiseventsqueue:
       queueName: cpr_nomis_events_queue
       dlqName: cpr_nomis_events_dlq
       subscribeTopicId: domainevents
       subscribeFilter: '{"eventType":["prisoner-offender-search.prisoner.created", "prisoner-offender-search.prisoner.updated"] }'
+      dlqMaxReceiveCount: 1
     cprnomismergeeventsqueue:
       queueName: cpr_nomis_merge_events_queue
       dlqName: cpr_nomis_merge_events_queue_dlq
       subscribeTopicId: domainevents
       subscribeFilter: '{"eventType":[ "prisoner-offender-events.prisoner.merged"] }'
+      dlqMaxReceiveCount: 1
   topics:
     courtcasestopic:
       arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}.fifo


### PR DESCRIPTION
Setting maxReceiveCount to 1 means that a message will go straight onto the dead letter queue if processing fails 