### PR TITLE
FIX: fix helm warning

### DIFF
--- a/helm_deploy/hmpps-person-record/templates/record-count-report-cron.yaml
+++ b/helm_deploy/hmpps-person-record/templates/record-count-report-cron.yaml
@@ -19,6 +19,14 @@ spec:
           containers:
             - name: record-count-report-job
               image: ghcr.io/ministryofjustice/hmpps-devops-tools
+              securityContext:
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                seccompProfile:
+                  type: RuntimeDefault
               args:
                 - /bin/sh
                 - -c


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-person-record/5819/workflows/b57f797c-c852-4bba-b6d4-1ac439e7e766/jobs/18321

> 
W0618 11:01:49.433072     448 warnings.go:67] would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "record-count-report-job" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "record-count-report-job" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "record-count-report-job" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "record-count-report-job" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")