### PR TITLE
CPR-780 order clusters by ID so last page does not keep changing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/admin/ClustersController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/admin/ClustersController.kt
@@ -34,7 +34,7 @@ class ClustersController(
   ): PaginatedResponse<AdminCluster> {
     val evaluatedPageable: Pageable = Pageable.ofSize(DEFAULT_PAGE_SIZE).withPage(page - 1)
     val paginatedClusters = withContext(Dispatchers.IO) {
-      personKeyRepository.findAllByStatus(UUIDStatusType.NEEDS_ATTENTION, evaluatedPageable)
+      personKeyRepository.findAllByStatusOrderById(UUIDStatusType.NEEDS_ATTENTION, evaluatedPageable)
     }
     val clusters = paginatedClusters.content.map {
       AdminCluster(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/PersonKeyRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/PersonKeyRepository.kt
@@ -12,5 +12,5 @@ import java.util.*
 interface PersonKeyRepository : JpaRepository<PersonKeyEntity, Long> {
   fun findByPersonUUID(personUUID: UUID?): PersonKeyEntity?
 
-  fun findAllByStatus(uuidStatus: UUIDStatusType, pageable: Pageable): Page<PersonKeyEntity>
+  fun findAllByStatusOrderById(uuidStatus: UUIDStatusType, pageable: Pageable): Page<PersonKeyEntity>
 }


### PR DESCRIPTION
Would be better to order by lastModified but we don't currently have it so this is better than nothing