### PR TITLE
CPR-769 disable autoscaling

### DIFF
--- a/helm_deploy/hmpps-person-record/values.yaml
+++ b/helm_deploy/hmpps-person-record/values.yaml
@@ -4,7 +4,7 @@ generic-service:
   serviceAccountName: "person-record-service"
 
   autoscaling:
-    enabled: true
+    enabled: false
     minReplicas: 2
     maxReplicas: 4
     targetCPUUtilizationPercentage: 75


### PR DESCRIPTION
after switching to GH actions, and during the deploy step to dev we get an error
https://github.com/ministryofjustice/hmpps-person-record/actions/runs/16776615871/job/47504860774

asking in the 'ask-cloud-platform' slack channel
the advise is to set the var to false

https://mojdt.slack.com/archives/C57UPMZLY/p1754486501083129?thread_ts=1754478058.938419&cid=C57UPMZLY