### PR TITLE
CPR-831 Rename Name data class for proper swagger documentation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/model/offender/ProbationCase.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/model/offender/ProbationCase.kt
@@ -6,7 +6,7 @@ import java.time.LocalDate
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ProbationCase(
   val title: Value? = null,
-  val name: Name,
+  val name: ProbationCaseName,
   val ethnicity: Value? = null,
   val identifiers: Identifiers,
   val dateOfBirth: LocalDate? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/model/offender/ProbationCaseAlias.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/model/offender/ProbationCaseAlias.kt
@@ -3,6 +3,6 @@ package uk.gov.justice.digital.hmpps.personrecord.client.model.offender
 import java.time.LocalDate
 
 data class ProbationCaseAlias(
-  val name: Name,
+  val name: ProbationCaseName,
   val dateOfBirth: LocalDate? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/model/offender/ProbationCaseName.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/model/offender/ProbationCaseName.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.personrecord.client.model.offender
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-data class Name(
+data class ProbationCaseName(
   @JsonProperty("forename")
   val firstName: String? = null,
   @JsonProperty("surname")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/IntegrationTestBase.kt
@@ -40,10 +40,10 @@ import uk.gov.justice.digital.hmpps.personrecord.client.model.match.PersonMatchS
 import uk.gov.justice.digital.hmpps.personrecord.client.model.match.isclustervalid.IsClusterValidResponse
 import uk.gov.justice.digital.hmpps.personrecord.client.model.match.isclustervalid.ValidCluster
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Identifiers
-import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationAddress
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCase
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseAlias
+import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Sentences
 import uk.gov.justice.digital.hmpps.personrecord.client.model.prisoner.Prisoner
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.EventLogEntity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/IntegrationTestBase.kt
@@ -40,7 +40,7 @@ import uk.gov.justice.digital.hmpps.personrecord.client.model.match.PersonMatchS
 import uk.gov.justice.digital.hmpps.personrecord.client.model.match.isclustervalid.IsClusterValidResponse
 import uk.gov.justice.digital.hmpps.personrecord.client.model.match.isclustervalid.ValidCluster
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Identifiers
-import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Name
+import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationAddress
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCase
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseAlias
@@ -86,7 +86,7 @@ import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.UUID
 import uk.gov.justice.digital.hmpps.personrecord.client.model.court.libra.Name as LibraName
-import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Name as OffenderName
+import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName as OffenderName
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
@@ -165,7 +165,7 @@ class IntegrationTestBase {
         ProbationAddress(postcode = randomPostcode()),
         ProbationAddress(postcode = randomPostcode()),
       ),
-      aliases = listOf(ProbationCaseAlias(Name(firstName = randomName(), middleNames = randomName(), lastName = randomName()), dateOfBirth = randomDate())),
+      aliases = listOf(ProbationCaseAlias(ProbationCaseName(firstName = randomName(), middleNames = randomName(), lastName = randomName()), dateOfBirth = randomDate())),
       sentences = listOf(Sentences(randomDate())),
     ),
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/canonical/CanonicalApiIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/canonical/CanonicalApiIntTest.kt
@@ -11,8 +11,8 @@ import uk.gov.justice.digital.hmpps.personrecord.api.model.canonical.CanonicalRe
 import uk.gov.justice.digital.hmpps.personrecord.api.model.canonical.CanonicalReligion
 import uk.gov.justice.digital.hmpps.personrecord.api.model.canonical.CanonicalTitle
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Identifiers
-import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCase
+import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName
 import uk.gov.justice.digital.hmpps.personrecord.config.WebTestBase
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Address
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Alias

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/canonical/CanonicalApiIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/canonical/CanonicalApiIntTest.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.personrecord.api.model.canonical.CanonicalRe
 import uk.gov.justice.digital.hmpps.personrecord.api.model.canonical.CanonicalReligion
 import uk.gov.justice.digital.hmpps.personrecord.api.model.canonical.CanonicalTitle
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Identifiers
-import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Name
+import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCase
 import uk.gov.justice.digital.hmpps.personrecord.config.WebTestBase
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Address
@@ -271,12 +271,12 @@ class CanonicalApiIntTest : WebTestBase() {
     val personKey = createPersonKey()
 
     createPerson(
-      Person.from(ProbationCase(name = Name(firstName = randomName(), middleNames = randomName(), lastName = randomName()), identifiers = Identifiers(crn = randomCrn()))),
+      Person.from(ProbationCase(name = ProbationCaseName(firstName = randomName(), middleNames = randomName(), lastName = randomName()), identifiers = Identifiers(crn = randomCrn()))),
       personKey,
     )
 
     val latestPerson = createPerson(
-      Person.from(ProbationCase(name = Name(firstName = randomName(), middleNames = randomName(), lastName = randomName()), identifiers = Identifiers(crn = randomCrn()))),
+      Person.from(ProbationCase(name = ProbationCaseName(firstName = randomName(), middleNames = randomName(), lastName = randomName()), identifiers = Identifiers(crn = randomCrn()))),
       personKey,
     )
 
@@ -430,12 +430,12 @@ class CanonicalApiIntTest : WebTestBase() {
     val personKey = createPersonKey()
 
     val person = createPerson(
-      Person.from(ProbationCase(name = Name(firstName = randomName(), middleNames = randomName(), lastName = randomName()), identifiers = Identifiers(crn = randomCrn()))),
+      Person.from(ProbationCase(name = ProbationCaseName(firstName = randomName(), middleNames = randomName(), lastName = randomName()), identifiers = Identifiers(crn = randomCrn()))),
       personKey,
     )
 
     val latestPerson = createPerson(
-      Person.from(ProbationCase(name = Name(firstName = randomName(), middleNames = randomName(), lastName = randomName()), identifiers = Identifiers(crn = randomCrn()))),
+      Person.from(ProbationCase(name = ProbationCaseName(firstName = randomName(), middleNames = randomName(), lastName = randomName()), identifiers = Identifiers(crn = randomCrn()))),
       personKey,
     )
 
@@ -462,12 +462,12 @@ class CanonicalApiIntTest : WebTestBase() {
     val personKey = createPersonKey()
 
     val person = createPerson(
-      Person.from(ProbationCase(name = Name(firstName = randomName(), middleNames = randomName(), lastName = randomName()), identifiers = Identifiers(crn = randomCrn()))),
+      Person.from(ProbationCase(name = ProbationCaseName(firstName = randomName(), middleNames = randomName(), lastName = randomName()), identifiers = Identifiers(crn = randomCrn()))),
       personKey,
     )
 
     val latestPerson = createPerson(
-      Person.from(ProbationCase(name = Name(firstName = randomName(), middleNames = randomName(), lastName = randomName()), identifiers = Identifiers(crn = randomCrn()))),
+      Person.from(ProbationCase(name = ProbationCaseName(firstName = randomName(), middleNames = randomName(), lastName = randomName()), identifiers = Identifiers(crn = randomCrn()))),
       personKey,
     )
 
@@ -498,11 +498,11 @@ class CanonicalApiIntTest : WebTestBase() {
     val targetPersonKey = createPersonKey()
 
     createPerson(
-      Person.from(ProbationCase(name = Name(firstName = sourcePersonFirstName), identifiers = Identifiers())),
+      Person.from(ProbationCase(name = ProbationCaseName(firstName = sourcePersonFirstName), identifiers = Identifiers())),
       personKeyEntity = sourcePersonKey,
     )
     createPerson(
-      Person.from(ProbationCase(name = Name(firstName = targetPersonFirstName), identifiers = Identifiers())),
+      Person.from(ProbationCase(name = ProbationCaseName(firstName = targetPersonFirstName), identifiers = Identifiers())),
       personKeyEntity = targetPersonKey,
     )
 
@@ -529,15 +529,15 @@ class CanonicalApiIntTest : WebTestBase() {
     val newTargetPersonKey = createPersonKey()
 
     createPerson(
-      Person.from(ProbationCase(name = Name(firstName = sourcePersonFirstName), identifiers = Identifiers())),
+      Person.from(ProbationCase(name = ProbationCaseName(firstName = sourcePersonFirstName), identifiers = Identifiers())),
       personKeyEntity = sourcePersonKey,
     )
     createPerson(
-      Person.from(ProbationCase(name = Name(firstName = targetPersonFirstName), identifiers = Identifiers())),
+      Person.from(ProbationCase(name = ProbationCaseName(firstName = targetPersonFirstName), identifiers = Identifiers())),
       personKeyEntity = targetPersonKey,
     )
     createPerson(
-      Person.from(ProbationCase(name = Name(firstName = newTargetPersonFirstName), identifiers = Identifiers())),
+      Person.from(ProbationCase(name = ProbationCaseName(firstName = newTargetPersonFirstName), identifiers = Identifiers())),
       personKeyEntity = newTargetPersonKey,
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/probation/ProbationApiIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/probation/ProbationApiIntTest.kt
@@ -7,10 +7,10 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.personrecord.api.constants.Roles.PROBATION_API_READ_WRITE
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ContactDetails
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Identifiers
-import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationAddress
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCase
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseAlias
+import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Value
 import uk.gov.justice.digital.hmpps.personrecord.config.WebTestBase
 import uk.gov.justice.digital.hmpps.personrecord.model.types.ContactType

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/probation/ProbationApiIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/controller/probation/ProbationApiIntTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.personrecord.api.constants.Roles.PROBATION_API_READ_WRITE
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ContactDetails
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Identifiers
-import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Name
+import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationAddress
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCase
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseAlias
@@ -79,7 +79,7 @@ class ProbationApiIntTest : WebTestBase() {
 
       val probationCase = ProbationCase(
         title = Value(value = title.name),
-        name = Name(
+        name = ProbationCaseName(
           firstName = firstName,
           middleNames = middleName,
           lastName = lastName,
@@ -93,7 +93,7 @@ class ProbationApiIntTest : WebTestBase() {
         dateOfBirth = dateOfBirth,
         aliases = listOf(
           ProbationCaseAlias(
-            name = Name(
+            name = ProbationCaseName(
               firstName = aliasFirstName,
               middleNames = aliasMiddleName,
               lastName = aliasLastName,
@@ -185,7 +185,7 @@ class ProbationApiIntTest : WebTestBase() {
       createPerson(createRandomProbationPersonDetails(crn))
 
       val probationCase = ProbationCase(
-        name = Name(firstName = randomName(), lastName = randomName()),
+        name = ProbationCaseName(firstName = randomName(), lastName = randomName()),
         identifiers = Identifiers(crn = crn, defendantId = randomDefendantId()),
       )
 
@@ -212,7 +212,7 @@ class ProbationApiIntTest : WebTestBase() {
       val offender = ProbationCase(
         title = Value(),
         identifiers = Identifiers(crn = randomCrn()),
-        name = Name(firstName = randomName()),
+        name = ProbationCaseName(firstName = randomName()),
         gender = Value(SexCode.M.name),
         ethnicity = Value(
           randomEthnicity(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/eventlog/EventLogServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/eventlog/EventLogServiceIntTest.kt
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Identifiers
-import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Name
+import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationAddress
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCase
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseAlias
@@ -34,13 +34,13 @@ class EventLogServiceIntTest : IntegrationTestBase() {
     val personEntity = createPersonWithNewKey(
       Person.from(
         ProbationCase(
-          name = Name(firstName = randomName(), middleNames = randomName(), lastName = randomName()),
+          name = ProbationCaseName(firstName = randomName(), middleNames = randomName(), lastName = randomName()),
           dateOfBirth = randomDate(),
           identifiers = Identifiers(crn = randomCrn(), cro = randomCro(), pnc = randomPnc()),
           addresses = listOf(ProbationAddress(postcode = randomPostcode())),
           aliases = listOf(
             ProbationCaseAlias(
-              name = Name(firstName = randomName(), lastName = randomName()),
+              name = ProbationCaseName(firstName = randomName(), lastName = randomName()),
               dateOfBirth = randomDate(),
             ),
           ),
@@ -116,16 +116,16 @@ class EventLogServiceIntTest : IntegrationTestBase() {
     val personEntity = createPersonWithNewKey(
       Person.from(
         ProbationCase(
-          name = Name(firstName = randomName(), lastName = randomName()),
+          name = ProbationCaseName(firstName = randomName(), lastName = randomName()),
           identifiers = Identifiers(crn = randomCrn(), cro = randomCro(), pnc = randomPnc()),
           addresses = listOf(ProbationAddress(postcode = "ZX1 1AB"), ProbationAddress(postcode = "AB1 2BC"), ProbationAddress(postcode = "ZX1 1AB")),
           aliases = listOf(
             ProbationCaseAlias(
-              name = Name(firstName = "Bob", lastName = "Smythe"),
+              name = ProbationCaseName(firstName = "Bob", lastName = "Smythe"),
               dateOfBirth = LocalDate.of(1970, 1, 1),
             ),
             ProbationCaseAlias(
-              name = Name(firstName = "Bob", lastName = "Smith"),
+              name = ProbationCaseName(firstName = "Bob", lastName = "Smith"),
               dateOfBirth = LocalDate.of(1980, 1, 1),
             ),
           ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/eventlog/EventLogServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/eventlog/EventLogServiceIntTest.kt
@@ -4,10 +4,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Identifiers
-import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationAddress
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCase
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseAlias
+import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Sentences
 import uk.gov.justice.digital.hmpps.personrecord.config.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Person

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/types/EthnicityCodeIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/types/EthnicityCodeIntTest.kt
@@ -20,7 +20,7 @@ import uk.gov.justice.digital.hmpps.personrecord.test.randomDefendantId
 import uk.gov.justice.digital.hmpps.personrecord.test.randomName
 import uk.gov.justice.digital.hmpps.personrecord.test.randomPrisonNumber
 import java.util.stream.Stream
-import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Name as OffenderName
+import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName as OffenderName
 
 class EthnicityCodeIntTest : IntegrationTestBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/types/NationalityCodeIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/types/NationalityCodeIntTest.kt
@@ -10,8 +10,8 @@ import uk.gov.justice.digital.hmpps.personrecord.client.model.court.commonplatfo
 import uk.gov.justice.digital.hmpps.personrecord.client.model.court.commonplatform.PersonDetails
 import uk.gov.justice.digital.hmpps.personrecord.client.model.court.event.LibraHearingEvent
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Identifiers
-import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCase
+import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Value
 import uk.gov.justice.digital.hmpps.personrecord.client.model.prisoner.Prisoner
 import uk.gov.justice.digital.hmpps.personrecord.config.IntegrationTestBase

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/types/NationalityCodeIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/types/NationalityCodeIntTest.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.personrecord.client.model.court.commonplatfo
 import uk.gov.justice.digital.hmpps.personrecord.client.model.court.commonplatform.PersonDetails
 import uk.gov.justice.digital.hmpps.personrecord.client.model.court.event.LibraHearingEvent
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Identifiers
-import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Name
+import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCase
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Value
 import uk.gov.justice.digital.hmpps.personrecord.client.model.prisoner.Prisoner
@@ -29,7 +29,7 @@ class NationalityCodeIntTest : IntegrationTestBase() {
 
   @Test
   fun `should handle null probation nationality code`() {
-    val probationCase = ProbationCase(name = Name(firstName = randomName()), identifiers = Identifiers(crn = randomCrn()), nationality = Value(null))
+    val probationCase = ProbationCase(name = ProbationCaseName(firstName = randomName()), identifiers = Identifiers(crn = randomCrn()), nationality = Value(null))
     val person = createPerson(Person.from(probationCase))
     assertThat(person.nationalities.size).isEqualTo(0)
   }
@@ -37,7 +37,7 @@ class NationalityCodeIntTest : IntegrationTestBase() {
   @ParameterizedTest
   @MethodSource("probationCodes")
   fun `should map probation nationality codes to cpr nationality codes`(probationCode: String, cprCode: NationalityCode, cprDescription: String) {
-    val probationCase = ProbationCase(name = Name(firstName = randomName()), identifiers = Identifiers(crn = randomCrn()), nationality = Value(probationCode))
+    val probationCase = ProbationCase(name = ProbationCaseName(firstName = randomName()), identifiers = Identifiers(crn = randomCrn()), nationality = Value(probationCode))
     val person = createPerson(Person.from(probationCase))
     assertThat(person.nationalities.first().nationalityCode?.code).isEqualTo(cprCode.name)
     assertThat(person.nationalities.first().nationalityCode?.description).isEqualTo(cprDescription)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/types/SexCodeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/types/SexCodeTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import uk.gov.justice.digital.hmpps.personrecord.client.model.court.commonplatform.PersonDetails
 import uk.gov.justice.digital.hmpps.personrecord.client.model.court.event.LibraHearingEvent
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Identifiers
-import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Name
+import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCase
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Value
 import uk.gov.justice.digital.hmpps.personrecord.client.model.prisoner.Prisoner
@@ -38,7 +38,7 @@ class SexCodeTest {
   @ParameterizedTest
   @MethodSource("probationEvent")
   fun `should map from probation event gender values`(genderCode: String?, sexCode: SexCode?) {
-    val probationCase = ProbationCase(name = Name(), identifiers = Identifiers(), gender = Value(genderCode))
+    val probationCase = ProbationCase(name = ProbationCaseName(), identifiers = Identifiers(), gender = Value(genderCode))
 
     assertThat(SexCode.from(probationCase)).isEqualTo(sexCode)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/types/SexCodeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/types/SexCodeTest.kt
@@ -7,8 +7,8 @@ import org.junit.jupiter.params.provider.MethodSource
 import uk.gov.justice.digital.hmpps.personrecord.client.model.court.commonplatform.PersonDetails
 import uk.gov.justice.digital.hmpps.personrecord.client.model.court.event.LibraHearingEvent
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Identifiers
-import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCase
+import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Value
 import uk.gov.justice.digital.hmpps.personrecord.client.model.prisoner.Prisoner
 import uk.gov.justice.digital.hmpps.personrecord.test.randomDate

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/types/TitleCodeIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/types/TitleCodeIntTest.kt
@@ -22,7 +22,7 @@ import uk.gov.justice.digital.hmpps.personrecord.test.randomName
 import uk.gov.justice.digital.hmpps.personrecord.test.randomPrisonNumber
 import java.util.stream.Stream
 import uk.gov.justice.digital.hmpps.personrecord.client.model.court.libra.Name as LibraName
-import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Name as OffenderName
+import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName as OffenderName
 
 class TitleCodeIntTest : IntegrationTestBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/CreateUpdateServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/CreateUpdateServiceIntTest.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.personrecord.service.message.CreateUpdateSer
 import uk.gov.justice.digital.hmpps.personrecord.test.randomCId
 import uk.gov.justice.digital.hmpps.personrecord.test.randomCrn
 import uk.gov.justice.digital.hmpps.personrecord.test.randomName
-import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.Name as OffenderName
+import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCaseName as OffenderName
 
 class CreateUpdateServiceIntTest : IntegrationTestBase() {
 


### PR DESCRIPTION
* Renamed as swagger evaluates the first `Name` object it finds as the docs so can have incorrect request payload examples with object of the same name