### PR TITLE
FIX: remove logs for when nationality code is unknown - nothing apart…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/types/nationality/NationalityCode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/types/nationality/NationalityCode.kt
@@ -248,19 +248,17 @@ enum class NationalityCode {
   ;
 
   companion object {
-    private val log = LoggerFactory.getLogger(this::class.java)
-
     fun fromProbationMapping(code: String?): NationalityCode? = code?.getNationalityOrUnknown(
       PROBATION_NATIONALITY_MAPPING,
-    ).also { if (it == UNKNOWN) log.info("Unknown nationality code probation: $code") }
+    )
 
     fun fromPrisonMapping(code: String?): NationalityCode? = code?.getNationalityOrUnknown(
       PRISON_NATIONALITY_MAPPING,
-    ).also { if (it == UNKNOWN) log.info("Unknown nationality code prison: $code") }
+    )
 
     fun fromCommonPlatformMapping(code: String?): NationalityCode? = code?.getNationalityOrUnknown(
       COMMON_PLATFORM_NATIONALITY_MAPPING,
-    ).also { if (it == UNKNOWN) log.info("Unknown nationality code common platform: $code") }
+    )
 
     private fun String?.getNationalityOrUnknown(nationalityMap: Map<String, NationalityCode>): NationalityCode? = this.normalize()?.let {
       nationalityMap[it] ?: UNKNOWN

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/types/nationality/NationalityCode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/types/nationality/NationalityCode.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.personrecord.model.types.nationality
 
-import org.slf4j.LoggerFactory
 import uk.gov.justice.digital.hmpps.personrecord.extentions.nullIfBlank
 
 enum class NationalityCode {


### PR DESCRIPTION
… from UNKNOWN seen for 3 weeks

[Go to Log Analytics and run query](https://portal.azure.com/#@747381f4-e81f-4a43-bf68-ced6a1e14edf/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fa5ddf257-3b21-4ba9-a28c-ab30f751b383%2FresourceGroups%2Fnomisapi-prod-rg%2Fproviders%2FMicrosoft.OperationalInsights%2Fworkspaces%2Fnomisapi-prod/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAAz3LsQ3CQAwAwJ4prDSBIiOkyAChQDCAeSz%252Blbxt2Y5eQQwPDfR3k%252BrVMJEf3tAyGcGkepGVzlgJxhH6XFV9UDIXHoyS2KP%252F45nc8UnggRbeSmTobrywNAbGKMK4lti7b%252FCtVrTyIkiycRxPcN9%252F%252FwMgD95ihgAAAA%253D%253D/timespan/2025-09-05T07%3A53%3A06.000Z%2F2025-09-22T07%3A53%3A06.035Z/limit/500000)