### PR TITLE
CPR-839-null-override

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/admin/AdminEventLogSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/admin/AdminEventLogSummary.kt
@@ -46,7 +46,7 @@ data class AdminEventLogDetails(
       middleNames = eventLogEntity.middleNames,
       lastName = eventLogEntity.lastName,
       lastNameAliases = eventLogEntity.lastNameAliases,
-      dateOfBirth = eventLogEntity.dateOfBirth.toString(),
+      dateOfBirth = eventLogEntity.dateOfBirth?.toString(),
       dateOfBirthAliases = eventLogEntity.dateOfBirthAliases.map { it.toString() }.toTypedArray(),
       postcodes = eventLogEntity.postcodes,
       pncs = eventLogEntity.pncs,
@@ -58,7 +58,7 @@ data class AdminEventLogDetails(
       eventTimestamp = eventLogEntity.eventTimestamp.toString(),
       sentenceDates = eventLogEntity.sentenceDates.map { it.toString() }.toTypedArray(),
       excludeOverrideMarkers = emptyArray(),
-      overrideMarker = eventLogEntity.overrideMarker.toString(),
+      overrideMarker = eventLogEntity.overrideMarker?.toString(),
       overrideScopes = eventLogEntity.overrideScopes.map { it.toString() }.toTypedArray(),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/admin/EventLogApiIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/admin/EventLogApiIntTest.kt
@@ -56,6 +56,8 @@ class EventLogApiIntTest : WebTestBase() {
     assertThat(response.eventLogs[1].uuidStatusType).isEqualTo("ACTIVE")
     assertThat(response.eventLogs[1].sourceSystem).isEqualTo("DELIUS")
     assertThat(response.eventLogs[1].sourceSystemId).isEqualTo(person.crn)
+    assertThat(response.eventLogs[1].overrideMarker).isNull()
+    assertThat(response.eventLogs[1].dateOfBirth).isNull()
   }
 
   @Test


### PR DESCRIPTION
change dob and override marker to return null instead of string null