### PR TITLE
CPR-1125 alternative

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/PersonKeyRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/PersonKeyRepository.kt
@@ -12,5 +12,7 @@ import java.util.UUID
 interface PersonKeyRepository : JpaRepository<PersonKeyEntity, Long> {
   fun findByPersonUUID(personUUID: UUID?): PersonKeyEntity?
 
+  fun findByMergedTo(mergedTo: Long?): PersonKeyEntity?
+
   fun findAllByStatusOrderById(uuidStatus: UUIDStatusType, pageable: Pageable): Page<PersonKeyEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/message/DeletionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/message/DeletionService.kt
@@ -54,6 +54,10 @@ class DeletionService(
   }
 
   private fun deletePersonKey(personKeyEntity: PersonKeyEntity, personEntity: PersonEntity) {
+    personKeyRepository.findByMergedTo(personKeyEntity.id)?.let {
+      personKeyRepository.delete(it) // TODO merge chains? Do they even exist??
+      // TODO possibly emit a PersonKeyDeleted event here?
+    }
     personKeyRepository.delete(personKeyEntity)
     publisher.publishEvent(PersonKeyDeleted(personEntity, personKeyEntity))
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/admin/ReclusterApiIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/admin/ReclusterApiIntTest.kt
@@ -46,7 +46,6 @@ class ReclusterApiIntTest : WebTestBase() {
 
       mergeRecord(mergedPerson, person)
 
-      mergedPerson.assertHasLinkToCluster()
       mergedPerson.assertMergedTo(person)
 
       val request = listOf(AdminReclusterRecord(DELIUS, mergedPerson.crn!!))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/canonical/CanonicalApiIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/canonical/CanonicalApiIntTest.kt
@@ -427,13 +427,28 @@ class CanonicalApiIntTest : WebTestBase() {
     val sourcePersonFirstName = randomName()
     val targetPersonFirstName = randomName()
 
-    val sourcePersonKey = createPersonKey()
-      .addPerson(Person.from(ProbationCase(name = ProbationCaseName(firstName = sourcePersonFirstName), identifiers = Identifiers())))
-    val targetPersonKey = createPersonKey().addPerson(
-      Person.from(ProbationCase(name = ProbationCaseName(firstName = targetPersonFirstName), identifiers = Identifiers())),
+    val sourcePerson = createPerson(
+      Person.from(
+        ProbationCase(
+          name = ProbationCaseName(firstName = sourcePersonFirstName),
+          identifiers = Identifiers(),
+        ),
+      ),
     )
-
-    mergeUuid(sourcePersonKey, targetPersonKey)
+    val sourcePersonKey = createPersonKey()
+      .addPerson(sourcePerson)
+    val targetPerson = createPerson(
+      Person.from(
+        ProbationCase(
+          name = ProbationCaseName(firstName = targetPersonFirstName),
+          identifiers = Identifiers(),
+        ),
+      ),
+    )
+    val targetPersonKey = createPersonKey().addPerson(
+      targetPerson,
+    )
+    mergeRecord(sourcePerson, targetPerson)
 
     webTestClient.get()
       .uri(canonicalAPIUrl(sourcePersonKey.personUUID.toString()))
@@ -451,21 +466,44 @@ class CanonicalApiIntTest : WebTestBase() {
     val targetPersonFirstName = randomName()
     val newTargetPersonFirstName = randomName()
 
+    val sourcePerson = createPerson(
+      Person.from(
+        ProbationCase(
+          name = ProbationCaseName(firstName = sourcePersonFirstName),
+          identifiers = Identifiers(),
+        ),
+      ),
+    )
     val sourcePersonKey = createPersonKey()
       .addPerson(
-        Person.from(ProbationCase(name = ProbationCaseName(firstName = sourcePersonFirstName), identifiers = Identifiers())),
+        sourcePerson,
       )
-    val targetPersonKey = createPersonKey()
+    val targetPerson = createPerson(
+      Person.from(
+        ProbationCase(
+          name = ProbationCaseName(firstName = targetPersonFirstName),
+          identifiers = Identifiers(),
+        ),
+      ),
+    )
+    createPersonKey()
       .addPerson(
-        Person.from(ProbationCase(name = ProbationCaseName(firstName = targetPersonFirstName), identifiers = Identifiers())),
+        targetPerson,
       )
+    val newTargetPerson = createPerson(
+      Person.from(
+        ProbationCase(
+          name = ProbationCaseName(firstName = newTargetPersonFirstName),
+          identifiers = Identifiers(),
+        ),
+      ),
+    )
     val newTargetPersonKey = createPersonKey()
       .addPerson(
-        Person.from(ProbationCase(name = ProbationCaseName(firstName = newTargetPersonFirstName), identifiers = Identifiers())),
+        newTargetPerson,
       )
-
-    mergeUuid(sourcePersonKey, targetPersonKey)
-    mergeUuid(targetPersonKey, newTargetPersonKey)
+    mergeRecord(sourcePerson, targetPerson)
+    mergeRecord(targetPerson, newTargetPerson)
 
     webTestClient.get()
       .uri(canonicalAPIUrl(sourcePersonKey.personUUID.toString()))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/IntegrationTestBase.kt
@@ -324,7 +324,7 @@ class IntegrationTestBase {
     }
   }
 
-  internal fun awaitAssert(function: () -> Unit) = await atMost (Duration.ofSeconds(12)) untilAsserted function
+  internal fun awaitAssert(function: () -> Unit) = await atMost (Duration.ofSeconds(5)) untilAsserted function
 
   internal fun <T> awaitNotNull(function: () -> T?): T = await atMost (Duration.ofSeconds(3)) untilNotNull function
 
@@ -355,11 +355,9 @@ class IntegrationTestBase {
     .apply(configure)
     .let(personRepository::saveAndFlush)
 
-  // TODO the personKey of the merged record is still set here
-  // TODO ideally replace this with full merge processing
   internal fun mergeRecord(sourcePersonEntity: PersonEntity, targetPersonEntity: PersonEntity) {
     stubDeletePersonMatch()
-    mergeService.processMerge(sourcePersonEntity, targetPersonEntity)
+    mergeService.processMerge(personRepository.findByMatchId(sourcePersonEntity.matchId), personRepository.findByMatchId(targetPersonEntity.matchId)!!)
   }
 
   internal fun mergeUuid(sourcePersonKey: PersonKeyEntity, targetPersonKeyEntity: PersonKeyEntity) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/IntegrationTestBase.kt
@@ -73,6 +73,7 @@ import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusType.ACTI
 import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusType.MERGED
 import uk.gov.justice.digital.hmpps.personrecord.model.types.review.ClusterType
 import uk.gov.justice.digital.hmpps.personrecord.service.eventlog.CPRLogEvents
+import uk.gov.justice.digital.hmpps.personrecord.service.message.MergeService
 import uk.gov.justice.digital.hmpps.personrecord.service.person.OverrideService
 import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType
 import uk.gov.justice.digital.hmpps.personrecord.telemetry.TelemetryTestRepository
@@ -114,6 +115,9 @@ class IntegrationTestBase {
 
   @Autowired
   lateinit var jsonMapper: JsonMapper
+
+  @Autowired
+  lateinit var mergeService: MergeService
 
   @Autowired
   lateinit var personKeyRepository: PersonKeyRepository
@@ -353,19 +357,17 @@ class IntegrationTestBase {
 
   // TODO the personKey of the merged record is still set here
   // TODO ideally replace this with full merge processing
-  internal fun mergeRecord(sourcePersonEntity: PersonEntity, targetPersonEntity: PersonEntity): PersonEntity {
-    val source = personRepository.findByMatchId(sourcePersonEntity.matchId)!!
-    val target = personRepository.findByMatchId(targetPersonEntity.matchId)!!
-    source.mergedTo = target.id
-    return personRepository.save(source)
+  internal fun mergeRecord(sourcePersonEntity: PersonEntity, targetPersonEntity: PersonEntity) {
+    stubDeletePersonMatch()
+    mergeService.processMerge(sourcePersonEntity, targetPersonEntity)
   }
 
-  internal fun mergeUuid(sourcePersonKey: PersonKeyEntity, targetPersonKeyEntity: PersonKeyEntity): PersonKeyEntity {
+  internal fun mergeUuid(sourcePersonKey: PersonKeyEntity, targetPersonKeyEntity: PersonKeyEntity) {
     val source = personKeyRepository.findByPersonUUID(sourcePersonKey.personUUID)!!
     val target = personKeyRepository.findByPersonUUID(targetPersonKeyEntity.personUUID)!!
     source.mergedTo = target.id
     source.status = MERGED
-    return personKeyRepository.saveAndFlush(source)
+    personKeyRepository.saveAndFlush(source)
   }
 
   internal fun excludeRecord(sourceRecord: PersonEntity, excludingRecord: PersonEntity) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/IntegrationTestBase.kt
@@ -70,7 +70,6 @@ import uk.gov.justice.digital.hmpps.personrecord.model.types.IdentifierType.PNC
 import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusReasonType
 import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusType
 import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusType.ACTIVE
-import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusType.MERGED
 import uk.gov.justice.digital.hmpps.personrecord.model.types.review.ClusterType
 import uk.gov.justice.digital.hmpps.personrecord.service.eventlog.CPRLogEvents
 import uk.gov.justice.digital.hmpps.personrecord.service.message.MergeService
@@ -358,14 +357,6 @@ class IntegrationTestBase {
   internal fun mergeRecord(sourcePersonEntity: PersonEntity, targetPersonEntity: PersonEntity) {
     stubDeletePersonMatch()
     mergeService.processMerge(personRepository.findByMatchId(sourcePersonEntity.matchId), personRepository.findByMatchId(targetPersonEntity.matchId)!!)
-  }
-
-  internal fun mergeUuid(sourcePersonKey: PersonKeyEntity, targetPersonKeyEntity: PersonKeyEntity) {
-    val source = personKeyRepository.findByPersonUUID(sourcePersonKey.personUUID)!!
-    val target = personKeyRepository.findByPersonUUID(targetPersonKeyEntity.personUUID)!!
-    source.mergedTo = target.id
-    source.status = MERGED
-    personKeyRepository.saveAndFlush(source)
   }
 
   internal fun excludeRecord(sourceRecord: PersonEntity, excludingRecord: PersonEntity) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationDeleteListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationDeleteListenerIntTest.kt
@@ -139,14 +139,14 @@ class ProbationDeleteListenerIntTest : MessagingMultiNodeTestBase() {
     )
     checkTelemetry(
       CPR_RECORD_DELETED,
-      mapOf("CRN" to recordBCrn, "UUID" to cluster.personUUID.toString(), "SOURCE_SYSTEM" to "DELIUS"),
+      mapOf("CRN" to recordBCrn, "SOURCE_SYSTEM" to "DELIUS"),
     )
     checkTelemetry(
       CPR_UUID_DELETED,
-      mapOf("CRN" to recordBCrn, "UUID" to cluster.personUUID.toString(), "SOURCE_SYSTEM" to "DELIUS"),
+      mapOf("CRN" to recordACrn, "UUID" to cluster.personUUID.toString(), "SOURCE_SYSTEM" to "DELIUS"),
     )
     checkEventLogExist(recordBCrn, CPRLogEvents.CPR_RECORD_DELETED)
-    checkEventLogExist(recordBCrn, CPRLogEvents.CPR_UUID_DELETED)
+    checkEventLogExist(recordACrn, CPRLogEvents.CPR_UUID_DELETED)
 
     recordA.assertPersonDeleted()
     recordB.assertPersonDeleted()
@@ -309,7 +309,7 @@ class ProbationDeleteListenerIntTest : MessagingMultiNodeTestBase() {
     )
     checkTelemetry(
       CPR_RECORD_DELETED,
-      mapOf("CRN" to recordBCrn, "UUID" to cluster.personUUID.toString(), "SOURCE_SYSTEM" to "DELIUS"),
+      mapOf("CRN" to recordBCrn, "SOURCE_SYSTEM" to "DELIUS"),
     )
     checkEventLogExist(recordACrn, CPRLogEvents.CPR_RECORD_DELETED)
     checkEventLogExist(recordBCrn, CPRLogEvents.CPR_RECORD_DELETED)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationDeleteListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationDeleteListenerIntTest.kt
@@ -162,7 +162,6 @@ class ProbationDeleteListenerIntTest : MessagingMultiNodeTestBase() {
     val mergedFrom = createPersonWithNewKey(createRandomProbationPersonDetails(recordBCrn))
 
     mergeRecord(mergedFrom, mergedTo)
-    mergeUuid(mergedFrom.personKey!!, mergedTo.personKey!!)
 
     publishProbationDomainEvent(OFFENDER_DELETION, recordACrn)
 
@@ -209,7 +208,6 @@ class ProbationDeleteListenerIntTest : MessagingMultiNodeTestBase() {
 
     mergeRecord(recordC, recordB)
     mergeRecord(recordB, recordA)
-    mergeUuid(recordB.personKey!!, recordA.personKey!!)
 
     publishProbationDomainEvent(OFFENDER_DELETION, recordACrn)
 
@@ -223,23 +221,18 @@ class ProbationDeleteListenerIntTest : MessagingMultiNodeTestBase() {
     )
     checkTelemetry(
       CPR_RECORD_DELETED,
-      mapOf("CRN" to recordBCrn, "UUID" to recordB.personKey?.personUUID.toString(), "SOURCE_SYSTEM" to "DELIUS"),
+      mapOf("CRN" to recordBCrn, "SOURCE_SYSTEM" to "DELIUS"),
     )
-    checkTelemetry(
-      CPR_UUID_DELETED,
-      mapOf("CRN" to recordBCrn, "UUID" to recordB.personKey?.personUUID.toString(), "SOURCE_SYSTEM" to "DELIUS"),
-    )
+
     checkEventLogExist(recordACrn, CPRLogEvents.CPR_RECORD_DELETED)
     checkEventLogExist(recordACrn, CPRLogEvents.CPR_UUID_DELETED)
     checkEventLogExist(recordBCrn, CPRLogEvents.CPR_RECORD_DELETED)
-    checkEventLogExist(recordBCrn, CPRLogEvents.CPR_UUID_DELETED)
     checkEventLogExist(recordCCrn, CPRLogEvents.CPR_RECORD_DELETED)
 
     recordA.assertPersonDeleted()
     recordB.assertPersonDeleted()
     recordC.assertPersonDeleted()
     recordA.personKey?.assertPersonKeyDeleted()
-    recordB.personKey?.assertPersonKeyDeleted()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationDeleteListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationDeleteListenerIntTest.kt
@@ -160,7 +160,7 @@ class ProbationDeleteListenerIntTest : MessagingMultiNodeTestBase() {
 
     val mergedTo = createPersonWithNewKey(createRandomProbationPersonDetails(recordACrn))
     val mergedFrom = createPersonWithNewKey(createRandomProbationPersonDetails(recordBCrn))
-
+    val mergedFromPersonKey = mergedFrom.personKey
     mergeRecord(mergedFrom, mergedTo)
 
     publishProbationDomainEvent(OFFENDER_DELETION, recordACrn)
@@ -175,20 +175,18 @@ class ProbationDeleteListenerIntTest : MessagingMultiNodeTestBase() {
     )
     checkTelemetry(
       CPR_RECORD_DELETED,
-      mapOf("CRN" to recordBCrn, "UUID" to mergedFrom.personKey?.personUUID.toString(), "SOURCE_SYSTEM" to "DELIUS"),
+      mapOf("CRN" to recordBCrn, "SOURCE_SYSTEM" to "DELIUS"),
     )
-    checkTelemetry(
-      CPR_UUID_DELETED,
-      mapOf("CRN" to recordBCrn, "UUID" to mergedFrom.personKey?.personUUID.toString(), "SOURCE_SYSTEM" to "DELIUS"),
-    )
+
     checkEventLogExist(recordACrn, CPRLogEvents.CPR_RECORD_DELETED)
     checkEventLogExist(recordACrn, CPRLogEvents.CPR_UUID_DELETED)
     checkEventLogExist(recordBCrn, CPRLogEvents.CPR_RECORD_DELETED)
-    checkEventLogExist(recordBCrn, CPRLogEvents.CPR_UUID_DELETED)
 
     mergedFrom.assertPersonDeleted()
     mergedTo.assertPersonDeleted()
-    mergedFrom.personKey?.assertPersonKeyDeleted()
+    mergedFromPersonKey!!.assertPersonKeyDeleted()
+    // this is a bug I think. mergedFrom's personKey has been merged to mergedTo's personKey but nothing in the DeletionService checks this to delete it
+    // this used to pass because the test setup was incorrect and left the personKey on the merged record set. In reality it would be null
     mergedTo.personKey?.assertPersonKeyDeleted()
   }
 
@@ -204,6 +202,7 @@ class ProbationDeleteListenerIntTest : MessagingMultiNodeTestBase() {
 
     // Second Record Cluster (2 Records - C merged to B)
     val recordB = createPersonWithNewKey(createRandomProbationPersonDetails(recordBCrn))
+    val recordBPersonKey = recordB.personKey
     val recordC = createPerson(createRandomProbationPersonDetails(recordCCrn))
 
     mergeRecord(recordC, recordB)
@@ -233,6 +232,9 @@ class ProbationDeleteListenerIntTest : MessagingMultiNodeTestBase() {
     recordB.assertPersonDeleted()
     recordC.assertPersonDeleted()
     recordA.personKey?.assertPersonKeyDeleted()
+    recordBPersonKey!!.assertPersonKeyDeleted()
+    // this is a bug I think. recordB's personKey has been merged to recordA's personKey but nothing in the DeletionService checks this to delete it
+    // this used to pass because the test setup was incorrect and left the personKey on the merged record set. In reality it would be null
   }
 
   @Test


### PR DESCRIPTION
I had a go at the requested behaviour of deleting the person key if a merge means the person key has no records left on it. It is quite far-reaching and I think we should do it.
While this is definitely a good idea, it was not anywhere near as easy as doing this simple alternative of deleting the orphaned person key when the merged to record is deleted :-)


