### PR TITLE
CPR-1050 move schedule to evening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ sonar-project.properties
 .trivyignore
 .vscode
 bin
+.DS_Store

--- a/helm_deploy/hmpps-person-record/values.yaml
+++ b/helm_deploy/hmpps-person-record/values.yaml
@@ -121,4 +121,4 @@ generic-prometheus-alerts:
 cron:
   recordCountReportJob: "0 0-23 * * *"
   reclusterNeedsAttentionJob: "0 13 * * *"
-  generateDeliusMergeRequestsJob: "0 7 * * 1-5"
+  generateDeliusMergeRequestsJob: "0 19 * * 1-5"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -49,6 +49,3 @@ generic-prometheus-alerts:
     - "hmpps-person-record-prod-cpr_nomis_merge_events_dlq"
   rdsAlertsDatabases:
     cloud-platform-325c1d58e0fe99fe: "hmpps-person-record-database"
-
-  cron:
-    generateDeliusMergeRequestsJob: "0 7 * * 2-6"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jobs/servicenow/ServiceNowMergeRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jobs/servicenow/ServiceNowMergeRequestService.kt
@@ -41,11 +41,8 @@ class ServiceNowMergeRequestService(
 
   fun getClustersForMergeRequests(): List<MergeRequestItem> {
     log.info("starting")
-    val thisTimeYesterday = LocalDateTime.now().minusDays(1)
-    val recordsModifiedYesterday = personRepository.findByLastModifiedBetween(
-      thisTimeYesterday,
-      thisTimeYesterday.plusHours(HOURS_TO_CHOOSE_FROM),
-    )
+    val tenHoursAgo = LocalDateTime.now().minusHours(HOURS_TO_CHOOSE_FROM)
+    val recordsModifiedYesterday = personRepository.findByLastModifiedAfter(tenHoursAgo)
     log.info("finished getting modified clusters for ${recordsModifiedYesterday.size}")
     val records = recordsModifiedYesterday
       .distinctBy { it.personKey }
@@ -89,7 +86,7 @@ class ServiceNowMergeRequestService(
 
   companion object {
     private const val CLUSTER_TO_PROCESS_COUNT = 5
-    private const val HOURS_TO_CHOOSE_FROM = 10L
+    const val HOURS_TO_CHOOSE_FROM = 10L
     private val log = LoggerFactory.getLogger(this::class.java)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/PersonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/repository/PersonRepository.kt
@@ -27,8 +27,7 @@ interface PersonRepository : JpaRepository<PersonEntity, Long> {
 
   fun countBySourceSystemAndMergedToIsNullAndPassiveStateFalse(sourceSystem: SourceSystemType): Long
 
-  fun findByLastModifiedBetween(
+  fun findByLastModifiedAfter(
     lastModifiedAfter: LocalDateTime,
-    lastModifiedBefore: LocalDateTime,
   ): MutableList<PersonEntity>
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/jobs/ServiceNowMergeRequestE2ETest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/jobs/ServiceNowMergeRequestE2ETest.kt
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import uk.gov.justice.digital.hmpps.personrecord.config.E2ETestBase
 import uk.gov.justice.digital.hmpps.personrecord.jobs.servicenow.ServiceNowMergeRequestRepository
+import uk.gov.justice.digital.hmpps.personrecord.jobs.servicenow.ServiceNowMergeRequestService.Companion.HOURS_TO_CHOOSE_FROM
 import uk.gov.justice.digital.hmpps.personrecord.jpa.repository.PersonRepository
 import uk.gov.justice.digital.hmpps.personrecord.service.type.OFFENDER_MERGED
 import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_RECORD_MERGED
@@ -112,7 +113,7 @@ class ServiceNowMergeRequestE2ETest : E2ETestBase() {
     val person11 = createRandomProbationPersonDetails()
     val person12 = person11.copy(crn = randomCrn())
 
-    val thisTimeYesterday = LocalDateTime.now().minusDays(1)
+    val tenHoursAgo = LocalDateTime.now().minusHours(HOURS_TO_CHOOSE_FROM)
     createPersonKey()
       .addPerson(person1)
       .addPerson(person2)
@@ -132,18 +133,18 @@ class ServiceNowMergeRequestE2ETest : E2ETestBase() {
       .addPerson(person11)
       .addPerson(person12)
 
-    personRepository.updateLastModifiedDate(person1.crn!!, thisTimeYesterday.plusMinutes(1))
-    personRepository.updateLastModifiedDate(person2.crn!!, thisTimeYesterday.plusMinutes(2))
-    personRepository.updateLastModifiedDate(person3.crn!!, thisTimeYesterday.plusMinutes(3))
-    personRepository.updateLastModifiedDate(person4.crn!!, thisTimeYesterday.plusMinutes(4))
-    personRepository.updateLastModifiedDate(person5.crn!!, thisTimeYesterday.plusMinutes(5))
-    personRepository.updateLastModifiedDate(person6.crn!!, thisTimeYesterday.plusMinutes(6))
-    personRepository.updateLastModifiedDate(person7.crn!!, thisTimeYesterday.plusMinutes(7))
-    personRepository.updateLastModifiedDate(person8.crn!!, thisTimeYesterday.plusMinutes(8))
-    personRepository.updateLastModifiedDate(person9.crn!!, thisTimeYesterday.plusMinutes(9))
-    personRepository.updateLastModifiedDate(person10.crn!!, thisTimeYesterday.plusMinutes(10))
-    personRepository.updateLastModifiedDate(person11.crn!!, thisTimeYesterday.plusMinutes(11))
-    personRepository.updateLastModifiedDate(person12.crn!!, thisTimeYesterday.plusMinutes(12))
+    personRepository.updateLastModifiedDate(person1.crn!!, tenHoursAgo.plusMinutes(1))
+    personRepository.updateLastModifiedDate(person2.crn!!, tenHoursAgo.plusMinutes(2))
+    personRepository.updateLastModifiedDate(person3.crn!!, tenHoursAgo.plusMinutes(3))
+    personRepository.updateLastModifiedDate(person4.crn!!, tenHoursAgo.plusMinutes(4))
+    personRepository.updateLastModifiedDate(person5.crn!!, tenHoursAgo.plusMinutes(5))
+    personRepository.updateLastModifiedDate(person6.crn!!, tenHoursAgo.plusMinutes(6))
+    personRepository.updateLastModifiedDate(person7.crn!!, tenHoursAgo.plusMinutes(7))
+    personRepository.updateLastModifiedDate(person8.crn!!, tenHoursAgo.plusMinutes(8))
+    personRepository.updateLastModifiedDate(person9.crn!!, tenHoursAgo.plusMinutes(9))
+    personRepository.updateLastModifiedDate(person10.crn!!, tenHoursAgo.plusMinutes(10))
+    personRepository.updateLastModifiedDate(person11.crn!!, tenHoursAgo.plusMinutes(11))
+    personRepository.updateLastModifiedDate(person12.crn!!, tenHoursAgo.plusMinutes(12))
 
     webTestClient.post()
       .uri(GENERATE_MERGE_REQUESTS)
@@ -158,7 +159,7 @@ class ServiceNowMergeRequestE2ETest : E2ETestBase() {
   fun `should not send a merge request for a cluster which has already had a merge request`() {
     val crn1 = randomCrn()
     val crn2 = randomCrn()
-    val thisTimeYesterday = LocalDateTime.now().minusDays(1)
+    val tenHoursAgo = LocalDateTime.now().minusHours(HOURS_TO_CHOOSE_FROM)
 
     val person1 = createRandomProbationPersonDetails(crn1)
     val person2 = createRandomProbationPersonDetails(crn2)
@@ -166,8 +167,8 @@ class ServiceNowMergeRequestE2ETest : E2ETestBase() {
       .addPerson(person1)
       .addPerson(person2)
 
-    personRepository.updateLastModifiedDate(crn1, thisTimeYesterday.plusMinutes(1))
-    personRepository.updateLastModifiedDate(crn2, thisTimeYesterday.plusMinutes(2))
+    personRepository.updateLastModifiedDate(crn1, tenHoursAgo.plusMinutes(1))
+    personRepository.updateLastModifiedDate(crn2, tenHoursAgo.plusMinutes(2))
 
     webTestClient.post()
       .uri(GENERATE_MERGE_REQUESTS)
@@ -217,13 +218,13 @@ class ServiceNowMergeRequestE2ETest : E2ETestBase() {
   fun `should not send a merge request for a cluster which has two prison records but no probation records`() {
     val prisonNumber1 = randomPrisonNumber()
     val prisonNumber2 = randomPrisonNumber()
-    val thisTimeYesterday = LocalDateTime.now().minusDays(1)
+    val tenHoursAgo = LocalDateTime.now().minusHours(HOURS_TO_CHOOSE_FROM)
     createPersonKey()
       .addPerson(createRandomPrisonPersonDetails(prisonNumber1))
       .addPerson(createRandomPrisonPersonDetails(prisonNumber2))
 
-    personRepository.updatePrisonerLastModifiedDate(prisonNumber1, thisTimeYesterday.plusMinutes(1))
-    personRepository.updatePrisonerLastModifiedDate(prisonNumber2, thisTimeYesterday.plusMinutes(2))
+    personRepository.updatePrisonerLastModifiedDate(prisonNumber1, tenHoursAgo.plusMinutes(1))
+    personRepository.updatePrisonerLastModifiedDate(prisonNumber2, tenHoursAgo.plusMinutes(2))
 
     webTestClient.post()
       .uri(GENERATE_MERGE_REQUESTS)
@@ -257,12 +258,12 @@ class ServiceNowMergeRequestE2ETest : E2ETestBase() {
         "SOURCE_SYSTEM" to "DELIUS",
       ),
     )
-    val thisTimeYesterday = LocalDateTime.now().minusDays(1)
+    val tenHoursAgo = LocalDateTime.now().minusHours(HOURS_TO_CHOOSE_FROM)
 
-    personRepository.updateLastModifiedDate(person1.crn!!, thisTimeYesterday.plusMinutes(1))
-    personRepository.updateLastModifiedDate(person2.crn!!, thisTimeYesterday.plusMinutes(2))
-    personRepository.updateLastModifiedDate(person3.crn!!, thisTimeYesterday.plusMinutes(2))
-    personRepository.updateLastModifiedDate(person4.crn!!, thisTimeYesterday.plusMinutes(2))
+    personRepository.updateLastModifiedDate(person1.crn!!, tenHoursAgo.plusMinutes(1))
+    personRepository.updateLastModifiedDate(person2.crn!!, tenHoursAgo.plusMinutes(2))
+    personRepository.updateLastModifiedDate(person3.crn!!, tenHoursAgo.plusMinutes(2))
+    personRepository.updateLastModifiedDate(person4.crn!!, tenHoursAgo.plusMinutes(2))
 
     webTestClient.post()
       .uri(GENERATE_MERGE_REQUESTS)


### PR DESCRIPTION
The job can run in all environments at 7pm UTC on weekdays, when all environments will be available. 

It can look back 10 hours over the working day to 9am UTC which should give plenty of clusters from which to pick merge request candidates