### PR TITLE
Cpr 1154 remove merged enum

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/admin/cluster/ClustersApiIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/admin/cluster/ClustersApiIntTest.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.personrecord.model.types.SourceSystemType.LI
 import uk.gov.justice.digital.hmpps.personrecord.model.types.SourceSystemType.NOMIS
 import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusType
 import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusType.ACTIVE
-import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusType.MERGED
 import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusType.RECLUSTER_MERGE
 
 class ClustersApiIntTest : WebTestBase() {
@@ -60,7 +59,6 @@ class ClustersApiIntTest : WebTestBase() {
   @Test
   fun `should not return clusters that are not NEEDS ATTENTION`() {
     createPersonWithNewKey(createRandomProbationPersonDetails(), status = ACTIVE)
-    createPersonWithNewKey(createRandomProbationPersonDetails(), status = MERGED)
     createPersonWithNewKey(createRandomProbationPersonDetails(), status = RECLUSTER_MERGE)
 
     val responseType = object : ParameterizedTypeReference<PaginatedResponse<AdminCluster>>() {}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/PersonMatchServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/PersonMatchServiceIntTest.kt
@@ -278,23 +278,6 @@ class PersonMatchServiceIntTest : IntegrationTestBase() {
 
       noCandidateFound(highConfidenceMatch)
     }
-
-    @Test
-    fun `should not return high confidence match with merged status`() {
-      val searchingRecord = createPerson(createExamplePerson())
-      createPersonKey()
-        .addPerson(searchingRecord)
-
-      val foundRecord = createPerson(createExamplePerson())
-      createPersonKey(UUIDStatusType.MERGED)
-        .addPerson(foundRecord)
-
-      stubOnePersonMatchAboveJoinThreshold(matchId = searchingRecord.matchId, matchedRecord = foundRecord.matchId)
-
-      val highConfidenceMatch = personMatchService.findClustersToJoin(searchingRecord)
-
-      noCandidateFound(highConfidenceMatch)
-    }
   }
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/ReclusterServiceE2ETest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/ReclusterServiceE2ETest.kt
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.hmpps.personrecord.model.person.Person
 import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusReasonType.BROKEN_CLUSTER
 import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusReasonType.OVERRIDE_CONFLICT
 import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusType.ACTIVE
-import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusType.MERGED
 import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusType.NEEDS_ATTENTION
 import uk.gov.justice.digital.hmpps.personrecord.model.types.UUIDStatusType.RECLUSTER_MERGE
 import uk.gov.justice.digital.hmpps.personrecord.service.eventlog.CPRLogEvents
@@ -535,27 +534,6 @@ class ReclusterServiceE2ETest : E2ETestBase() {
 
       cluster1.assertClusterStatus(ACTIVE)
       cluster2.assertClusterStatus(RECLUSTER_MERGE)
-    }
-
-    @Test
-    fun `should not merge an active cluster to a matched cluster marked as merged`() {
-      val basePersonData = createRandomProbationCase()
-
-      val personA = createProbationPerson(basePersonData)
-      val cluster1 = createPersonKey()
-        .addPerson(personA)
-
-      val personB = createMatchingRecord(basePersonData)
-      val cluster2 = createPersonKey(MERGED)
-        .addPerson(personB)
-
-      recluster(personA)
-
-      cluster1.assertClusterIsOfSize(1)
-      cluster2.assertClusterIsOfSize(1)
-
-      cluster1.assertClusterStatus(ACTIVE)
-      cluster2.assertClusterStatus(MERGED)
     }
   }
 


### PR DESCRIPTION
Only use of MERGED status for clusters is in IntegrationTestBase