### PR TITLE
CPR-1154 Drop merged_to column from person_key table

### DIFF
--- a/src/main/resources/db/migration/V192__drop_person_key_merged_to_column.sql
+++ b/src/main/resources/db/migration/V192__drop_person_key_merged_to_column.sql
@@ -1,0 +1,8 @@
+BEGIN;
+-------------------------------------------------------
+
+ALTER TABLE IF EXISTS personrecordservice.person_key
+    DROP COLUMN merged_to;
+
+-----------------------------------------------------
+COMMIT;


### PR DESCRIPTION
No longer merging clusters so this is not needed.