### PR TITLE
CPR-1138 remove check for merged records

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/search/PersonMatchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/search/PersonMatchService.kt
@@ -101,7 +101,7 @@ class PersonMatchService(
 
   private fun List<PersonMatchResult>.allowMatchesWithUUID(): List<PersonMatchResult> = this.filter { it.personEntity.personKey != PersonKeyEntity.empty }
 
-  private fun List<PersonMatchResult>.removePassiveRecords(): List<PersonMatchResult> = this.filterNot { it.personEntity.isPassive() } // TODO delete me
+  private fun List<PersonMatchResult>.removePassiveRecords(): List<PersonMatchResult> = this.filterNot { it.personEntity.isPassive() }
 
   private fun List<PersonMatchResult>.logCandidateSearchSummary(personEntity: PersonEntity, totalNumberOfScores: Int): List<PersonMatchResult> {
     val canJoinCount = this.getClustersThatItCanJoin()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/search/PersonMatchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/search/PersonMatchService.kt
@@ -40,7 +40,6 @@ class PersonMatchService(
     val personScores = collectPersonScores(personEntity)
     val aboveFractureThresholdPersonRecords = getPersonRecords(personScores.getClustersAboveFractureThreshold())
       .allowMatchesWithUUID()
-      .removeMergedRecords()
       .removePassiveRecords()
       .logCandidateSearchSummary(personEntity, totalNumberOfScores = personScores.size)
       .sortedByDescending { it.matchWeight }
@@ -102,9 +101,7 @@ class PersonMatchService(
 
   private fun List<PersonMatchResult>.allowMatchesWithUUID(): List<PersonMatchResult> = this.filter { it.personEntity.personKey != PersonKeyEntity.empty }
 
-  private fun List<PersonMatchResult>.removeMergedRecords(): List<PersonMatchResult> = this.filter { it.personEntity.mergedTo == null }
-
-  private fun List<PersonMatchResult>.removePassiveRecords(): List<PersonMatchResult> = this.filterNot { it.personEntity.isPassive() }
+  private fun List<PersonMatchResult>.removePassiveRecords(): List<PersonMatchResult> = this.filterNot { it.personEntity.isPassive() } // TODO delete me
 
   private fun List<PersonMatchResult>.logCandidateSearchSummary(personEntity: PersonEntity, totalNumberOfScores: Int): List<PersonMatchResult> {
     val canJoinCount = this.getClustersThatItCanJoin()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/PersonMatchServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/PersonMatchServiceIntTest.kt
@@ -178,25 +178,6 @@ class PersonMatchServiceIntTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `should not return high confidence match has been merged to another record`() {
-      val searchingRecord = createPerson(createExamplePerson())
-      createPersonKey()
-        .addPerson(searchingRecord)
-
-      val mergedToRecord = createPerson(createExamplePerson())
-      val foundRecord = createPerson(createExamplePerson()) { mergedTo = mergedToRecord.id }
-      createPersonKey()
-        .addPerson(foundRecord)
-        .addPerson(mergedToRecord)
-
-      stubOnePersonMatchAboveJoinThreshold(matchId = searchingRecord.matchId, matchedRecord = foundRecord.matchId)
-
-      val highConfidenceMatch = personMatchService.findClustersToJoin(searchingRecord)
-
-      noCandidateFound(highConfidenceMatch)
-    }
-
-    @Test
     fun `should not return high confidence match to a passive state record`() {
       val searchingRecord = createPerson(createExamplePerson())
       createPersonKey()


### PR DESCRIPTION
 which will not be in hmpps-person-match anyway and will not have a UUID either
 
 https://github.com/ministryofjustice/hmpps-person-record/blob/aacc6c6cf60e753527647ccecb5b50d2f529e58d/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/search/PersonMatchService.kt#L42 will already have removed any merged records which somehow remained in `hmpps-person-match` (which should not be possible anyway)