### PR TITLE
FIX: set timezone for scheduled downtime cronjob to respect BST

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,8 +17,9 @@ generic-service:
 
   scheduledDowntime:
     enabled: true
-    # Start at 6:35am UTC Monday-Friday - 5 minutes after hmpps-person-match
+    # Start at 6:35am Monday-Friday - 5 minutes after hmpps-person-match
     startup: '35 6 * * 1-5'
+    timeZone: Europe/London
 
 generic-prometheus-alerts:
   businessHoursOnly: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -17,8 +17,9 @@ generic-service:
 
   scheduledDowntime:
     enabled: true
-    # Start at 6:35am UTC Monday-Friday - 5 minutes after hmpps-person-match
+    # Start at 6:35am Monday-Friday - 5 minutes after hmpps-person-match
     startup: '35 6 * * 1-5'
+    timeZone: Europe/London
 
 generic-prometheus-alerts:
   businessHoursOnly: true


### PR DESCRIPTION
https://github.com/ministryofjustice/hmpps-helm-charts/blob/9b8a897760449cc2f97b7d6f662c0e77c4e34a8f/charts/generic-service/templates/scheduled-downtime-cronjob.yaml#L41

This will hopefully stop the alerts in preprod every morning, caused by a buildup of court messages before the app starts up. This has been happening one hour later than usual since the clocks went forward