### PR TITLE
FIX: fixing warnings which appear on each build

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/admin/ReclusterController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/admin/ReclusterController.kt
@@ -57,7 +57,6 @@ class ReclusterController(
     SourceSystemType.LIBRA -> personRepository.findByCId(record.sourceSystemId)
     SourceSystemType.NOMIS -> personRepository.findByPrisonNumber(record.sourceSystemId)
     SourceSystemType.DELIUS -> personRepository.findByCrn(record.sourceSystemId)
-    else -> null
   }
 
   private fun List<AdminReclusterRecord>.forEachPersonAndLog(processName: String, action: (PersonEntity) -> Unit) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/person/Person.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/person/Person.kt
@@ -67,8 +67,6 @@ data class Person(
 
   companion object {
 
-    fun List<Reference>.toString(): String = this.joinToString { it.identifierValue.toString() }
-
     fun from(probationCase: ProbationCase): Person {
       val contacts: List<Contact> = listOfNotNull(
         Contact.from(ContactType.HOME, probationCase.contactDetails?.telephone),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/person/Person.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/person/Person.kt
@@ -226,7 +226,7 @@ data class Person(
       val primaryAlias = prisoner.pseudonyms.firstOrNull { it.isPrimary == true } ?: throw IllegalArgumentException("No primary alias was found for update on prisoner $prisonNumber")
 
       val references = prisoner.pseudonyms
-        .flatMap { it.identifiers?.toList() ?: emptyList() }
+        .flatMap { it.identifiers.toList() }
         .map { Reference.from(it) }
 
       return Person(


### PR DESCRIPTION
w: file:///home/runner/work/hmpps-person-record/hmpps-person-record/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/admin/ReclusterController.kt:60:5 'when' is exhaustive so 'else' is redundant here.

w: file:///home/runner/work/hmpps-person-record/hmpps-person-record/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/model/person/Person.kt:229:34 Unnecessary safe call on a non-null receiver of type 'List<Identifier>'.