### PR TITLE
Recluster test improvements

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/probation/ProbationApiE2ETest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/probation/ProbationApiE2ETest.kt
@@ -638,7 +638,6 @@ class ProbationApiE2ETest : E2ETestBase() {
           mapOf("SOURCE_SYSTEM" to "DELIUS", "CRN" to probationCase.identifiers.crn),
         )
 
-        offender.personKey?.assertClusterIsOfSize(2)
         assertThat(offender.masterDefendantId).isEqualTo(defendant.masterDefendantId)
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/probation/ProbationApiE2ETest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/probation/ProbationApiE2ETest.kt
@@ -637,7 +637,7 @@ class ProbationApiE2ETest : E2ETestBase() {
           CPR_RECORD_UPDATED,
           mapOf("SOURCE_SYSTEM" to "DELIUS", "CRN" to probationCase.identifiers.crn),
         )
-        offender.personKey?.assertClusterStatus(ACTIVE)
+
         offender.personKey?.assertClusterIsOfSize(2)
         assertThat(offender.masterDefendantId).isEqualTo(defendant.masterDefendantId)
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/ReclusterServiceE2ETest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/ReclusterServiceE2ETest.kt
@@ -37,24 +37,6 @@ class ReclusterServiceE2ETest : E2ETestBase() {
   inner class ClusterAlreadySetAsNeedsAttention {
 
     @Test
-    fun `should change from needs attention status to active when the non-matching record is updated to match the other records in the cluster above the join threshold`() {
-      val basePersonData = createRandomProbationCase()
-
-      val recordA = createProbationPerson(basePersonData)
-      val matchesA = createMatchingRecord(basePersonData)
-      val doesNotMatch = createProbationPerson()
-      val cluster = createPersonKey(status = NEEDS_ATTENTION, reason = BROKEN_CLUSTER)
-        .addPerson(recordA)
-        .addPerson(matchesA)
-        .addPerson(doesNotMatch)
-
-      probationDomainEventAndResponseSetup(eventType = OFFENDER_PERSONAL_DETAILS_UPDATED, ApiResponseSetup.from(basePersonData, crn = doesNotMatch.crn!!))
-
-      cluster.assertClusterIsOfSize(3)
-      cluster.assertClusterStatus(ACTIVE)
-    }
-
-    @Test
     fun `should change from needs attention status with null reason to active when the non-matching record is updated to match the other records in the cluster above the join threshold`() {
       val basePersonData = createRandomProbationCase()
 
@@ -173,7 +155,7 @@ class ReclusterServiceE2ETest : E2ETestBase() {
     }
 
     @Test
-    fun `should retain needs attention if the cluster has one record in it after a delete but was a override conflict`() {
+    fun `should retain needs attention if the cluster has one record in it after a delete but was an override conflict`() {
       val basePersonData = createRandomProbationCase()
 
       val recordA = createProbationPerson(basePersonData)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/ReclusterServiceE2ETest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/ReclusterServiceE2ETest.kt
@@ -4,7 +4,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationAddress
 import uk.gov.justice.digital.hmpps.personrecord.config.E2ETestBase
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.PersonEntity
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.PersonKeyEntity
@@ -23,8 +22,16 @@ import uk.gov.justice.digital.hmpps.personrecord.service.type.OFFENDER_UNMERGED
 import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_RECLUSTER_CLUSTER_RECORDS_NOT_LINKED
 import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_RECLUSTER_MERGE
 import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_RECLUSTER_SELF_HEALED
+import uk.gov.justice.digital.hmpps.personrecord.test.messages.CommonPlatformHearingSetup
+import uk.gov.justice.digital.hmpps.personrecord.test.messages.CommonPlatformHearingSetupAddress
+import uk.gov.justice.digital.hmpps.personrecord.test.messages.CommonPlatformHearingSetupAlias
+import uk.gov.justice.digital.hmpps.personrecord.test.messages.commonPlatformHearing
+import uk.gov.justice.digital.hmpps.personrecord.test.randomCommonPlatformSexCode
 import uk.gov.justice.digital.hmpps.personrecord.test.randomCrn
-import uk.gov.justice.digital.hmpps.personrecord.test.randomDigit
+import uk.gov.justice.digital.hmpps.personrecord.test.randomCro
+import uk.gov.justice.digital.hmpps.personrecord.test.randomDefendantId
+import uk.gov.justice.digital.hmpps.personrecord.test.randomLongPnc
+import uk.gov.justice.digital.hmpps.personrecord.test.randomName
 import uk.gov.justice.digital.hmpps.personrecord.test.randomPostcode
 import uk.gov.justice.digital.hmpps.personrecord.test.responses.ApiResponseSetup
 
@@ -56,22 +63,36 @@ class ReclusterServiceE2ETest : E2ETestBase() {
 
     @Test
     fun `should change from needs attention status to active when the non-matching record is updated to match the other records in the cluster above the fracture threshold`() {
-      val baseAddressData = ProbationAddress(postcode = randomPostcode())
-      val basePersonData = createRandomProbationCase()
-      val nonMatchingProbationCase = createRandomProbationCase()
-
-      val recordA = createProbationPerson(basePersonData.copy(addresses = listOf(baseAddressData.copy(deliusAddressId = randomDigit().toLong()))))
-      val matchesA = createMatchingRecord(basePersonData.copy(addresses = listOf(baseAddressData.copy(deliusAddressId = randomDigit().toLong()))))
-      val doesNotMatch = createProbationPerson(nonMatchingProbationCase.copy(addresses = listOf(baseAddressData.copy(deliusAddressId = randomDigit().toLong()))))
-      val cluster = createPersonKey(status = NEEDS_ATTENTION, reason = BROKEN_CLUSTER)
-        .addPerson(recordA)
-        .addPerson(matchesA)
-        .addPerson(doesNotMatch)
-
-      probationDomainEventAndResponseSetup(eventType = OFFENDER_PERSONAL_DETAILS_UPDATED, ApiResponseSetup.from(basePersonData.aboveFracture(), doesNotMatch.crn!!))
-
+      val nonMatchingDefendantId = randomDefendantId()
+      val basePersonSetup = CommonPlatformHearingSetup(
+        middleName = randomName(),
+        gender = randomCommonPlatformSexCode().key,
+        pnc = randomLongPnc(),
+        cro = randomCro(),
+        defendantId = randomDefendantId(),
+        aliases = listOf(CommonPlatformHearingSetupAlias(randomName(), randomName())),
+        address = CommonPlatformHearingSetupAddress("", "", "", "", "", randomPostcode()),
+      )
+      publishCommonPlatformMessage(
+        commonPlatformHearing(listOf(basePersonSetup, basePersonSetup.copy(defendantId = randomDefendantId()), basePersonSetup.copy(defendantId = nonMatchingDefendantId))),
+      )
+      val cluster = awaitNotNull { personRepository.findByDefendantId(nonMatchingDefendantId)?.personKey }
       cluster.assertClusterIsOfSize(3)
       cluster.assertClusterStatus(ACTIVE)
+
+      publishCommonPlatformMessage(commonPlatformHearing(listOf(CommonPlatformHearingSetup(defendantId = nonMatchingDefendantId))))
+      awaitAssert {
+        personRepository.findByDefendantId(nonMatchingDefendantId)?.personKey
+        cluster.assertClusterStatus(NEEDS_ATTENTION, BROKEN_CLUSTER)
+      }
+
+      publishCommonPlatformMessage(
+        commonPlatformHearing(listOf(aboveFractureMatch(basePersonSetup, nonMatchingDefendantId))),
+      )
+      awaitAssert {
+        personRepository.findByDefendantId(nonMatchingDefendantId)?.personKey
+        cluster.assertClusterStatus(ACTIVE)
+      }
     }
 
     @Test
@@ -175,6 +196,11 @@ class ReclusterServiceE2ETest : E2ETestBase() {
       cluster.assertClusterStatus(NEEDS_ATTENTION, reason = OVERRIDE_CONFLICT)
     }
   }
+
+  private fun aboveFractureMatch(
+    basePersonSetup: CommonPlatformHearingSetup,
+    defendantId: String,
+  ): CommonPlatformHearingSetup = basePersonSetup.copy(defendantId = defendantId, cro = "", pnc = "", masterDefendantId = defendantId)
 
   @Nested
   inner class ClusterWithExclusionOverride {


### PR DESCRIPTION
 A step away from using probation data to set up E2E reclustering tests. The fact that the address is no longer updated when updating a probation person has led to complications and tests failing intermittently. We could instead use court data where the whole message is processed. This avoids having to setup a callback for an API.



# 🚨 READ THIS 🚨

Does this change...
* [ ] 🔨 Have any downstream breaking changes
* [ ] 🚩 Need Feature flagged
* [ ] 🔀 Require any database migrations
* [ ] 🔔 Alerting of any other teams of changes
* [ ] ☁️ Need to provision/update any cloud platform resources
* [ ] ⚡️ Benefit from running the [load tests](https://github.com/ministryofjustice/hmpps-person-record-gatling)
