### PR TITLE
CPR-1150-remove-additional-info

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/model/sqs/messages/domainevent/AdditionalInformation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/model/sqs/messages/domainevent/AdditionalInformation.kt
@@ -1,8 +1,10 @@
 package uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class AdditionalInformation(
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/AddressDomainEventPublisherE2ETest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/AddressDomainEventPublisherE2ETest.kt
@@ -46,6 +46,7 @@ class AddressDomainEventPublisherE2ETest : E2ETestBase() {
     val sqsMessage = rawDomainEventMessage?.get()?.messages()?.first()?.let { jsonMapper.readValue<SQSMessage>(it.body()) }!!
     assertThat(sqsMessage.messageAttributes?.eventType).isEqualTo(MessageAttribute(CPR_PROBATION_ADDRESS_CREATED))
     assertThat(sqsMessage.messageAttributes?.eventSource).isEqualTo(MessageAttribute(CPR.identifier))
+    assertThat(sqsMessage.message.contains("unmergedCRN")).isFalse()
 
     val domainEvent: DomainEvent = jsonMapper.readValue(sqsMessage.message)
     assertThat(domainEvent.eventType).isEqualTo(CPR_PROBATION_ADDRESS_CREATED)


### PR DESCRIPTION
remove additional information from address event where values are null

# 🚨 READ THIS 🚨

Does this change...
* [ ] 🔨 Have any downstream breaking changes
* [ ] 🚩 Need Feature flagged
* [ ] 🔀 Require any database migrations
* [ ] 🔔 Alerting of any other teams of changes
* [ ] ☁️ Need to provision/update any cloud platform resources
* [ ] ⚡️ Benefit from running the [load tests](https://github.com/ministryofjustice/hmpps-person-record-gatling)
