### PR TITLE
updated AddressDomainEventPublisherE2ETest to use common assertion logic

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/probation/ProbationAddressPostAPIControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/probation/ProbationAddressPostAPIControllerTest.kt
@@ -4,35 +4,38 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.reactive.server.expectBody
 import tools.jackson.databind.node.ObjectNode
 import uk.gov.justice.digital.hmpps.personrecord.api.constants.Roles.PROBATION_API_READ_WRITE
 import uk.gov.justice.digital.hmpps.personrecord.api.model.probation.Address
 import uk.gov.justice.digital.hmpps.personrecord.api.model.probation.ProbationCreateAddressResponse
-import uk.gov.justice.digital.hmpps.personrecord.config.WebTestBase
+import uk.gov.justice.digital.hmpps.personrecord.config.E2ETestBase
 import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.AddressEntity
+import uk.gov.justice.digital.hmpps.personrecord.service.DomainEventSource.CPR
+import uk.gov.justice.digital.hmpps.personrecord.service.type.CPR_PROBATION_ADDRESS_CREATED
 import uk.gov.justice.digital.hmpps.personrecord.test.randomCrn
 
-class ProbationAddressPostAPIControllerTest : WebTestBase() {
+class ProbationAddressPostAPIControllerTest : E2ETestBase() {
 
   @Nested
   inner class SuccessfulProcessing {
     @Test
-    fun `should create a new address and recluster`() {
-      stubPersonMatchUpsert()
-      stubPersonMatchScores()
-
+    fun `should create a new address - recluster person - publish domain event`() {
       val crn = randomCrn()
       val newAddress = createRandomProbationAddress()
       createPersonWithNewKey(createRandomProbationPersonDetails(crn).copy(addresses = emptyList()))
 
-      val responseBody = sendPostRequestAsserted<ProbationCreateAddressResponse>(
-        url = probationAddressApiUrl(crn),
-        body = newAddress,
-        roles = listOf(PROBATION_API_READ_WRITE),
-        expectedStatus = HttpStatus.CREATED,
-      ).returnResult().responseBody!!
+      val responseBody = webTestClient
+        .post()
+        .uri(probationAddressApiUrl(crn))
+        .headers(jwtAuthorisationHelper.setAuthorisationHeader(roles = listOf(PROBATION_API_READ_WRITE)))
+        .bodyValue(newAddress)
+        .exchange()
+        .expectStatus()
+        .isCreated
+        .expectBody<ProbationCreateAddressResponse>()
+        .returnResult().responseBody!!
 
       awaitAssert {
         val personEntity = personRepository.findByCrn(crn) ?: fail("No person found with id $crn")
@@ -44,6 +47,12 @@ class ProbationAddressPostAPIControllerTest : WebTestBase() {
         assertThat(responseBody.crn).isEqualTo(crn)
         assertThat(responseBody.cprAddressId).isEqualTo(actualAddress.updateId.toString())
       }
+
+      checkDomainEventPublished(
+        crn = crn,
+        expectedEventType = CPR_PROBATION_ADDRESS_CREATED,
+        eventSource = CPR,
+      )
     }
 
     @Test
@@ -52,12 +61,16 @@ class ProbationAddressPostAPIControllerTest : WebTestBase() {
       val newAddress = createRandomProbationAddress()
       createPersonWithNewKey(createRandomProbationPersonDetails(crn).copy(addresses = emptyList())) { this.passiveState = true }
 
-      val responseBody = sendPostRequestAsserted<ProbationCreateAddressResponse>(
-        url = probationAddressApiUrl(crn),
-        body = newAddress,
-        roles = listOf(PROBATION_API_READ_WRITE),
-        expectedStatus = HttpStatus.CREATED,
-      ).returnResult().responseBody!!
+      val responseBody = webTestClient
+        .post()
+        .uri(probationAddressApiUrl(crn))
+        .headers(jwtAuthorisationHelper.setAuthorisationHeader(roles = listOf(PROBATION_API_READ_WRITE)))
+        .bodyValue(newAddress)
+        .exchange()
+        .expectStatus()
+        .isCreated
+        .expectBody<ProbationCreateAddressResponse>()
+        .returnResult().responseBody!!
 
       awaitAssert {
         val personEntity = personRepository.findByCrn(crn) ?: fail("No person found with id $crn")
@@ -73,9 +86,6 @@ class ProbationAddressPostAPIControllerTest : WebTestBase() {
 
     @Test
     fun `should create a new address with typeVerified as true when typeVerified is not supplied`() {
-      stubPersonMatchUpsert()
-      stubPersonMatchScores()
-
       val crn = randomCrn()
       val newAddress = createRandomProbationAddress()
       createPersonWithNewKey(createRandomProbationPersonDetails(crn).copy(addresses = emptyList()))
@@ -84,12 +94,16 @@ class ProbationAddressPostAPIControllerTest : WebTestBase() {
       val json = jsonMapper.valueToTree<ObjectNode>(newAddress)
       json.remove("typeVerified")
 
-      val responseBody = sendPostRequestAsserted<ProbationCreateAddressResponse>(
-        url = probationAddressApiUrl(crn),
-        body = json,
-        roles = listOf(PROBATION_API_READ_WRITE),
-        expectedStatus = HttpStatus.CREATED,
-      ).returnResult().responseBody!!
+      val responseBody = webTestClient
+        .post()
+        .uri(probationAddressApiUrl(crn))
+        .headers(jwtAuthorisationHelper.setAuthorisationHeader(roles = listOf(PROBATION_API_READ_WRITE)))
+        .bodyValue(newAddress)
+        .exchange()
+        .expectStatus()
+        .isCreated
+        .expectBody<ProbationCreateAddressResponse>()
+        .returnResult().responseBody!!
 
       awaitAssert {
         val personEntity = personRepository.findByCrn(crn) ?: fail("No person found with id $crn")
@@ -108,12 +122,14 @@ class ProbationAddressPostAPIControllerTest : WebTestBase() {
   inner class ErrorScenarios {
     @Test
     fun `should return 404 not found when probation record does not exist`() {
-      sendPostRequestAsserted<Unit>(
-        url = probationAddressApiUrl(randomCrn()),
-        body = createRandomProbationAddress(),
-        roles = listOf(PROBATION_API_READ_WRITE),
-        expectedStatus = HttpStatus.NOT_FOUND,
-      )
+      webTestClient
+        .post()
+        .uri(probationAddressApiUrl(randomCrn()))
+        .headers(jwtAuthorisationHelper.setAuthorisationHeader(roles = listOf(PROBATION_API_READ_WRITE)))
+        .bodyValue(createRandomProbationAddress())
+        .exchange()
+        .expectStatus()
+        .isNotFound
     }
 
     @Test
@@ -121,33 +137,37 @@ class ProbationAddressPostAPIControllerTest : WebTestBase() {
       val mergedCrn = randomCrn()
       val person = createPersonWithNewKey(createRandomProbationPersonDetails())
       createPerson(createRandomProbationPersonDetails(mergedCrn)) { mergedTo = person.id }
-      sendPostRequestAsserted<Unit>(
-        url = probationAddressApiUrl(mergedCrn),
-        body = createRandomProbationAddress(),
-        roles = listOf(PROBATION_API_READ_WRITE),
-        expectedStatus = HttpStatus.NOT_FOUND,
-      )
+      webTestClient
+        .post()
+        .uri(probationAddressApiUrl(mergedCrn))
+        .headers(jwtAuthorisationHelper.setAuthorisationHeader(roles = listOf(PROBATION_API_READ_WRITE)))
+        .bodyValue(createRandomProbationAddress())
+        .exchange()
+        .expectStatus()
+        .isNotFound
     }
 
     @Test
     fun `should return Access Denied 403 when role is wrong`() {
-      sendPostRequestAsserted<Unit>(
-        url = probationAddressApiUrl(randomCrn()),
-        body = createRandomProbationAddress(),
-        roles = listOf("UNSUPPORTED_ROLE"),
-        expectedStatus = HttpStatus.FORBIDDEN,
-      )
+      webTestClient
+        .post()
+        .uri(probationAddressApiUrl(randomCrn()))
+        .headers(jwtAuthorisationHelper.setAuthorisationHeader(roles = listOf("UNSUPPORTED_ROLE")))
+        .bodyValue(createRandomProbationAddress())
+        .exchange()
+        .expectStatus()
+        .isForbidden
     }
 
     @Test
     fun `should return UNAUTHORIZED 401 when role is not set`() {
-      sendPostRequestAsserted<Unit>(
-        url = probationAddressApiUrl(randomCrn()),
-        body = createRandomProbationAddress(),
-        roles = listOf("UNSUPPORTED_ROLE"),
-        expectedStatus = HttpStatus.UNAUTHORIZED,
-        sendAuthorised = false,
-      )
+      webTestClient
+        .post()
+        .uri(probationAddressApiUrl(randomCrn()))
+        .bodyValue(createRandomProbationAddress())
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
     }
   }
 
@@ -160,12 +180,14 @@ class ProbationAddressPostAPIControllerTest : WebTestBase() {
       val newAddress = createRandomProbationAddress()
       createPersonWithNewKey(createRandomProbationPersonDetails(crn).copy(addresses = emptyList()))
 
-      sendPostRequestAsserted<Unit>(
-        url = probationAddressApiUrl(crn),
-        body = newAddress,
-        roles = listOf(PROBATION_API_READ_WRITE),
-        expectedStatus = HttpStatus.NOT_FOUND,
-      )
+      webTestClient
+        .post()
+        .uri(probationAddressApiUrl(crn))
+        .headers(jwtAuthorisationHelper.setAuthorisationHeader(roles = listOf(PROBATION_API_READ_WRITE)))
+        .bodyValue(newAddress)
+        .exchange()
+        .expectStatus()
+        .isNotFound
 
       awaitAssert {
         val personEntity = personRepository.findByCrn(crn) ?: fail("No person found with id $crn")
@@ -183,12 +205,14 @@ class ProbationAddressPostAPIControllerTest : WebTestBase() {
       val newAddress = createRandomProbationAddress()
       createPersonWithNewKey(createRandomProbationPersonDetails(crn).copy(addresses = emptyList()))
 
-      sendPostRequestAsserted<Unit>(
-        url = probationAddressApiUrl(crn),
-        body = newAddress,
-        roles = listOf(PROBATION_API_READ_WRITE),
-        expectedStatus = HttpStatus.NOT_FOUND,
-      )
+      webTestClient
+        .post()
+        .uri(probationAddressApiUrl(crn))
+        .headers(jwtAuthorisationHelper.setAuthorisationHeader(roles = listOf(PROBATION_API_READ_WRITE)))
+        .bodyValue(newAddress)
+        .exchange()
+        .expectStatus()
+        .isNotFound
 
       awaitAssert {
         val personEntity = personRepository.findByCrn(crn) ?: fail("No person found with id $crn")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/MessagingTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/MessagingTestBase.kt
@@ -304,7 +304,7 @@ abstract class MessagingTestBase : IntegrationTestBase() {
 
   fun assertDomainEventPublishedAfterSasEvent(expectedEventType: String, crn: String) = checkDomainEventPublished(crn, expectedEventType, CPR)
 
-  private fun checkDomainEventPublished(
+  fun checkDomainEventPublished(
     crn: String,
     expectedEventType: String,
     eventSource: DomainEventSource,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/MessagingTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/MessagingTestBase.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.personrecord.config
 
 import com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED
+import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilCallTo
@@ -8,15 +9,26 @@ import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
 import software.amazon.awssdk.services.sns.model.MessageAttributeValue
 import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+import tools.jackson.module.kotlin.readValue
 import uk.gov.justice.digital.hmpps.personrecord.client.model.court.MessageType
 import uk.gov.justice.digital.hmpps.personrecord.client.model.court.MessageType.COMMON_PLATFORM_HEARING
 import uk.gov.justice.digital.hmpps.personrecord.client.model.court.MessageType.LIBRA_COURT_CASE
+import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.MessageAttribute
+import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.SQSMessage
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.AdditionalInformation
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.DomainEvent
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.PersonIdentifier
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.PersonReference
+import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.getCrn
+import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.AddressEntity
+import uk.gov.justice.digital.hmpps.personrecord.service.DomainEventSource
+import uk.gov.justice.digital.hmpps.personrecord.service.DomainEventSource.CPR
+import uk.gov.justice.digital.hmpps.personrecord.service.DomainEventSource.DELIUS
 import uk.gov.justice.digital.hmpps.personrecord.service.queue.LARGE_CASE_EVENT_TYPE
 import uk.gov.justice.digital.hmpps.personrecord.service.queue.Queues
+import uk.gov.justice.digital.hmpps.personrecord.service.type.CPR_PROBATION_ADDRESS_CREATED
+import uk.gov.justice.digital.hmpps.personrecord.service.type.CPR_PROBATION_ADDRESS_UPDATED
 import uk.gov.justice.digital.hmpps.personrecord.test.responses.ApiResponseSetup
 import uk.gov.justice.hmpps.sqs.HmppsQueue
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
@@ -283,6 +295,49 @@ abstract class MessagingTestBase : IntegrationTestBase() {
         ),
       ),
     )
+  }
+
+  fun assertDomainEventPublishedAfterDeliusEvent(expectedEventType: String, crn: String) {
+    val (addressEntity, domainEvent: DomainEvent) = checkDomainEventPublished(crn, expectedEventType, DELIUS)
+    assertThat(domainEvent.additionalInformation?.outboundDeliusAddressId).isEqualTo(addressEntity.deliusAddressId.toString())
+  }
+
+  fun assertDomainEventPublishedAfterSasEvent(expectedEventType: String, crn: String) = checkDomainEventPublished(crn, expectedEventType, CPR)
+
+  private fun checkDomainEventPublished(
+    crn: String,
+    expectedEventType: String,
+    eventSource: DomainEventSource,
+  ): Pair<AddressEntity, DomainEvent> {
+    val actualPersonEntity = awaitNotNull { personRepository.findByCrn(crn) }
+    assertThat(actualPersonEntity.addresses.size).isEqualTo(1)
+    val addressEntity = actualPersonEntity.addresses.first()
+
+    expectOneMessageOn(testOnlyCPRDomainEventsQueue)
+    val rawDomainEventMessage = testOnlyCPRDomainEventsQueue?.sqsClient?.receiveMessage(
+      ReceiveMessageRequest.builder().queueUrl(testOnlyCPRDomainEventsQueue?.queueUrl).build(),
+    )
+    val sqsMessage =
+      rawDomainEventMessage?.get()?.messages()?.first()?.let { jsonMapper.readValue<SQSMessage>(it.body()) }!!
+    assertThat(sqsMessage.getEventType()).isEqualTo(expectedEventType)
+    assertThat(sqsMessage.messageAttributes?.eventSource).isEqualTo(MessageAttribute(eventSource.identifier))
+    assertThat(sqsMessage.message.contains("unmergedCRN")).isFalse()
+
+    val domainEvent: DomainEvent = jsonMapper.readValue(sqsMessage.message)
+    assertThat(domainEvent.eventType).isEqualTo(expectedEventType)
+    assertThat(domainEvent.detailUrl).isEqualTo("http://localhost:8080/person/probation/$crn/address/${addressEntity.updateId}")
+    assertThat(domainEvent.description).isEqualTo(expectedDescription(expectedEventType))
+    assertThat(domainEvent.occurredAt).isNotNull()
+    assertThat(domainEvent.personReference?.identifiers?.size).isEqualTo(1)
+    assertThat(domainEvent.getCrn()).isEqualTo(crn)
+    assertThat(domainEvent.additionalInformation?.cprAddressId).isEqualTo(addressEntity.updateId.toString())
+    return Pair(addressEntity, domainEvent)
+  }
+
+  private fun expectedDescription(eventType: String): String = when (eventType) {
+    CPR_PROBATION_ADDRESS_CREATED -> "A probation address has been created for a person"
+    CPR_PROBATION_ADDRESS_UPDATED -> "A probation address has been updated for a person"
+    else -> error("Unsupported event type: $eventType")
   }
 
   @BeforeEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListenerTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListenerTestBase.kt
@@ -1,28 +1,17 @@
 package uk.gov.justice.digital.hmpps.personrecord.message.listeners.probation
 
 import org.assertj.core.api.Assertions.assertThat
-import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
-import tools.jackson.module.kotlin.readValue
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationAddress
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationAddressStatus
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationAddressUsage
-import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.MessageAttribute
-import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.SQSMessage
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.AdditionalInformation
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.DomainEvent
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.PersonIdentifier
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.PersonReference
-import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.getCrn
 import uk.gov.justice.digital.hmpps.personrecord.config.MessagingMultiNodeTestBase
-import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.AddressEntity
 import uk.gov.justice.digital.hmpps.personrecord.model.types.AddressStatusCode
 import uk.gov.justice.digital.hmpps.personrecord.model.types.AddressUsageCode
 import uk.gov.justice.digital.hmpps.personrecord.model.types.ContactType
-import uk.gov.justice.digital.hmpps.personrecord.service.DomainEventSource
-import uk.gov.justice.digital.hmpps.personrecord.service.DomainEventSource.CPR
-import uk.gov.justice.digital.hmpps.personrecord.service.DomainEventSource.DELIUS
-import uk.gov.justice.digital.hmpps.personrecord.service.type.CPR_PROBATION_ADDRESS_CREATED
-import uk.gov.justice.digital.hmpps.personrecord.service.type.CPR_PROBATION_ADDRESS_UPDATED
 import uk.gov.justice.digital.hmpps.personrecord.test.randomAddressNumber
 import uk.gov.justice.digital.hmpps.personrecord.test.randomBoolean
 import uk.gov.justice.digital.hmpps.personrecord.test.randomDigit
@@ -133,47 +122,5 @@ class ProbationEventListenerTestBase : MessagingMultiNodeTestBase() {
       assertThat(actualAddressEntity.contacts.first().contactType).isEqualTo(ContactType.HOME)
       assertThat(actualAddressEntity.contacts.first().contactValue).isEqualTo(probationAddress.telephoneNumber)
     }
-  }
-
-  fun assertDomainEventPublishedAfterDeliusEvent(expectedEventType: String, crn: String) {
-    val (addressEntity, domainEvent: DomainEvent) = checkDomainEventPublished(crn, expectedEventType, DELIUS)
-    assertThat(domainEvent.additionalInformation?.outboundDeliusAddressId).isEqualTo(addressEntity.deliusAddressId.toString())
-  }
-
-  fun assertDomainEventPublishedAfterSasEvent(expectedEventType: String, crn: String) = checkDomainEventPublished(crn, expectedEventType, CPR)
-
-  private fun checkDomainEventPublished(
-    crn: String,
-    expectedEventType: String,
-    eventSource: DomainEventSource,
-  ): Pair<AddressEntity, DomainEvent> {
-    val actualPersonEntity = awaitNotNull { personRepository.findByCrn(crn) }
-    assertThat(actualPersonEntity.addresses.size).isEqualTo(1)
-    val addressEntity = actualPersonEntity.addresses.first()
-
-    expectOneMessageOn(testOnlyCPRDomainEventsQueue)
-    val rawDomainEventMessage = testOnlyCPRDomainEventsQueue?.sqsClient?.receiveMessage(
-      ReceiveMessageRequest.builder().queueUrl(testOnlyCPRDomainEventsQueue?.queueUrl).build(),
-    )
-    val sqsMessage =
-      rawDomainEventMessage?.get()?.messages()?.first()?.let { jsonMapper.readValue<SQSMessage>(it.body()) }!!
-    assertThat(sqsMessage.getEventType()).isEqualTo(expectedEventType)
-    assertThat(sqsMessage.messageAttributes?.eventSource).isEqualTo(MessageAttribute(eventSource.identifier))
-
-    val domainEvent: DomainEvent = jsonMapper.readValue(sqsMessage.message)
-    assertThat(domainEvent.eventType).isEqualTo(expectedEventType)
-    assertThat(domainEvent.detailUrl).isEqualTo("http://localhost:8080/person/probation/$crn/address/${addressEntity.updateId}")
-    assertThat(domainEvent.description).isEqualTo(expectedDescription(expectedEventType))
-    assertThat(domainEvent.occurredAt).isNotNull()
-    assertThat(domainEvent.personReference?.identifiers?.size).isEqualTo(1)
-    assertThat(domainEvent.getCrn()).isEqualTo(crn)
-    assertThat(domainEvent.additionalInformation?.cprAddressId).isEqualTo(addressEntity.updateId.toString())
-    return Pair(addressEntity, domainEvent)
-  }
-
-  private fun expectedDescription(eventType: String): String = when (eventType) {
-    CPR_PROBATION_ADDRESS_CREATED -> "A probation address has been created for a person"
-    CPR_PROBATION_ADDRESS_UPDATED -> "A probation address has been updated for a person"
-    else -> error("Unsupported event type: $eventType")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/AddressDomainEventPublisherE2ETest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/AddressDomainEventPublisherE2ETest.kt
@@ -1,25 +1,18 @@
 package uk.gov.justice.digital.hmpps.personrecord.service
 
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.expectBody
-import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
-import tools.jackson.module.kotlin.readValue
 import uk.gov.justice.digital.hmpps.personrecord.api.constants.Roles.PROBATION_API_READ_WRITE
 import uk.gov.justice.digital.hmpps.personrecord.api.model.probation.ProbationCreateAddressResponse
-import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.MessageAttribute
-import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.SQSMessage
-import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.DomainEvent
 import uk.gov.justice.digital.hmpps.personrecord.config.E2ETestBase
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Address
 import uk.gov.justice.digital.hmpps.personrecord.service.DomainEventSource.CPR
 import uk.gov.justice.digital.hmpps.personrecord.service.address.AddressService
 import uk.gov.justice.digital.hmpps.personrecord.service.type.CPR_PROBATION_ADDRESS_CREATED
 import uk.gov.justice.digital.hmpps.personrecord.test.randomCrn
-import java.util.UUID
 
 class AddressDomainEventPublisherE2ETest : E2ETestBase() {
 
@@ -32,7 +25,7 @@ class AddressDomainEventPublisherE2ETest : E2ETestBase() {
     val newAddress = createRandomProbationAddress()
     createPersonWithNewKey(createRandomProbationPersonDetails(crn).copy(addresses = emptyList()))
 
-    val responseBody = webTestClient
+    webTestClient
       .post()
       .uri(probationAddressApiUrl(crn))
       .headers(jwtAuthorisationHelper.setAuthorisationHeader(roles = listOf(PROBATION_API_READ_WRITE)))
@@ -43,27 +36,10 @@ class AddressDomainEventPublisherE2ETest : E2ETestBase() {
       .expectBody<ProbationCreateAddressResponse>()
       .returnResult().responseBody!!
 
-    val createdAddress = addressRepository.findByUpdateId(UUID.fromString(responseBody.cprAddressId))
-
-    expectOneMessageOn(testOnlyCPRDomainEventsQueue)
-    val rawDomainEventMessage = testOnlyCPRDomainEventsQueue?.sqsClient?.receiveMessage(
-      ReceiveMessageRequest.builder().queueUrl(testOnlyCPRDomainEventsQueue?.queueUrl).build(),
+    assertDomainEventPublishedAfterSasEvent(
+      expectedEventType = CPR_PROBATION_ADDRESS_CREATED,
+      crn = crn,
     )
-    val sqsMessage = rawDomainEventMessage?.get()?.messages()?.first()?.let { jsonMapper.readValue<SQSMessage>(it.body()) }!!
-    assertThat(sqsMessage.messageAttributes?.eventType).isEqualTo(MessageAttribute(CPR_PROBATION_ADDRESS_CREATED))
-    assertThat(sqsMessage.messageAttributes?.eventSource).isEqualTo(MessageAttribute(CPR.identifier))
-    assertThat(sqsMessage.message.contains("unmergedCRN")).isFalse()
-
-    val domainEvent: DomainEvent = jsonMapper.readValue(sqsMessage.message)
-    assertThat(domainEvent.eventType).isEqualTo(CPR_PROBATION_ADDRESS_CREATED)
-    assertThat(domainEvent.detailUrl).isEqualTo("http://localhost:8080/person/probation/$crn/address/${createdAddress?.updateId}")
-    assertThat(domainEvent.description).isEqualTo("A probation address has been created for a person")
-    assertThat(domainEvent.occurredAt).isNotNull()
-    assertThat(domainEvent.personReference?.identifiers?.size).isEqualTo(1)
-    assertThat(domainEvent.personReference?.identifiers?.get(0)?.type).isEqualTo("CRN")
-    assertThat(domainEvent.personReference?.identifiers?.get(0)?.value).isEqualTo(crn)
-    assertThat(domainEvent.additionalInformation?.cprAddressId).isEqualTo(createdAddress?.updateId.toString())
-    assertThat(domainEvent.additionalInformation?.outboundDeliusAddressId).isNull()
   }
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/AddressDomainEventPublisherE2ETest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/AddressDomainEventPublisherE2ETest.kt
@@ -4,9 +4,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.reactive.server.expectBody
-import uk.gov.justice.digital.hmpps.personrecord.api.constants.Roles.PROBATION_API_READ_WRITE
-import uk.gov.justice.digital.hmpps.personrecord.api.model.probation.ProbationCreateAddressResponse
 import uk.gov.justice.digital.hmpps.personrecord.config.E2ETestBase
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Address
 import uk.gov.justice.digital.hmpps.personrecord.service.DomainEventSource.CPR
@@ -20,25 +17,22 @@ class AddressDomainEventPublisherE2ETest : E2ETestBase() {
   private lateinit var addressService: AddressService
 
   @Test
-  fun `should publish a CPR address created domain event when an address is created in sas`() {
+  fun `should publish a CPR address created domain event when an address is created`() {
     val crn = randomCrn()
-    val newAddress = createRandomProbationAddress()
-    createPersonWithNewKey(createRandomProbationPersonDetails(crn).copy(addresses = emptyList()))
+    val newAddress = Address.from(createRandomProbationAddress())
+    val personEntity = createPersonWithNewKey(createRandomProbationPersonDetails(crn).copy(addresses = emptyList()))
 
-    webTestClient
-      .post()
-      .uri(probationAddressApiUrl(crn))
-      .headers(jwtAuthorisationHelper.setAuthorisationHeader(roles = listOf(PROBATION_API_READ_WRITE)))
-      .bodyValue(newAddress)
-      .exchange()
-      .expectStatus()
-      .isCreated
-      .expectBody<ProbationCreateAddressResponse>()
-      .returnResult().responseBody!!
+    addressService.processAddress(
+      address = newAddress,
+      findPerson = { personEntity },
+      findAddress = { null },
+      eventSource = CPR,
+    )
 
-    assertDomainEventPublishedAfterSasEvent(
-      expectedEventType = CPR_PROBATION_ADDRESS_CREATED,
+    checkDomainEventPublished(
       crn = crn,
+      expectedEventType = CPR_PROBATION_ADDRESS_CREATED,
+      eventSource = CPR,
     )
   }
 
@@ -81,6 +75,4 @@ class AddressDomainEventPublisherE2ETest : E2ETestBase() {
       expectNoMessagesOn(testOnlyCPRDomainEventsQueue)
     }
   }
-
-  private fun probationAddressApiUrl(crn: String) = "/person/probation/$crn/address"
 }


### PR DESCRIPTION
# 🚨 READ THIS 🚨

Does this change...
* [ ] 🔨 Have any downstream breaking changes
* [ ] 🚩 Need Feature flagged
* [ ] 🔀 Require any database migrations
* [ ] 🔔 Alerting of any other teams of changes
* [ ] ☁️ Need to provision/update any cloud platform resources
* [ ] ⚡️ Benefit from running the [load tests](https://github.com/ministryofjustice/hmpps-person-record-gatling)
