### PR TITLE
CPR-1202 Ignore Probation address update events when eventSource == CPR

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListener.kt
@@ -36,7 +36,8 @@ class ProbationEventListener(
     when {
       patchAddressEvent(event, eventSource) -> deliusAddressIdHandler.patchAddress(event)
       createAddressEvent(event, eventSource) -> upsertAddress(event)
-      updateAddressEvent(event) -> upsertAddress(event)
+      updateAddressEvent(event,eventSource) -> upsertAddress(event)
+      ignoreUpdateEvent(event, eventSource) -> {}
       deleteAddressEvent(event) -> deleteAddress(event)
       else -> updateWholePerson(event)
     }
@@ -46,7 +47,9 @@ class ProbationEventListener(
 
   private fun createAddressEvent(event: DomainEvent, eventSource: String?) = eventSource != DomainEventSource.CPR.identifier && event.eventType == OFFENDER_ADDRESS_CREATED
 
-  private fun updateAddressEvent(event: DomainEvent) = event.eventType == OFFENDER_ADDRESS_UPDATED
+  private fun updateAddressEvent(event: DomainEvent, eventSource: String?) = eventSource != DomainEventSource.CPR.identifier && event.eventType == OFFENDER_ADDRESS_UPDATED
+
+  private fun ignoreUpdateEvent(event: DomainEvent, eventSource: String?) = eventSource == DomainEventSource.CPR.identifier && event.eventType == OFFENDER_ADDRESS_UPDATED
 
   private fun deleteAddressEvent(event: DomainEvent) = event.eventType == OFFENDER_ADDRESS_DELETED
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListener.kt
@@ -36,8 +36,8 @@ class ProbationEventListener(
     when {
       patchAddressEvent(event, eventSource) -> deliusAddressIdHandler.patchAddress(event)
       createAddressEvent(event, eventSource) -> upsertAddress(event)
-      updateAddressEvent(event,eventSource) -> upsertAddress(event)
-      ignoreUpdateEvent(event, eventSource) -> {}
+      updateAddressEvent(event, eventSource) -> upsertAddress(event)
+      ignoreUpdateAddressEvent(event, eventSource) -> {}
       deleteAddressEvent(event) -> deleteAddress(event)
       else -> updateWholePerson(event)
     }
@@ -49,7 +49,7 @@ class ProbationEventListener(
 
   private fun updateAddressEvent(event: DomainEvent, eventSource: String?) = eventSource != DomainEventSource.CPR.identifier && event.eventType == OFFENDER_ADDRESS_UPDATED
 
-  private fun ignoreUpdateEvent(event: DomainEvent, eventSource: String?) = eventSource == DomainEventSource.CPR.identifier && event.eventType == OFFENDER_ADDRESS_UPDATED
+  private fun ignoreUpdateAddressEvent(event: DomainEvent, eventSource: String?) = eventSource == DomainEventSource.CPR.identifier && event.eventType == OFFENDER_ADDRESS_UPDATED
 
   private fun deleteAddressEvent(event: DomainEvent) = event.eventType == OFFENDER_ADDRESS_DELETED
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationAddressUpdatedEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationAddressUpdatedEventListenerIntTest.kt
@@ -6,12 +6,10 @@ import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Address
-import uk.gov.justice.digital.hmpps.personrecord.service.DomainEventSource
 import uk.gov.justice.digital.hmpps.personrecord.service.DomainEventSource.CPR
 import uk.gov.justice.digital.hmpps.personrecord.service.type.CPR_PROBATION_ADDRESS_CREATED
 import uk.gov.justice.digital.hmpps.personrecord.service.type.CPR_PROBATION_ADDRESS_UPDATED
 import uk.gov.justice.digital.hmpps.personrecord.service.type.OFFENDER_ADDRESS_UPDATED
-import uk.gov.justice.digital.hmpps.personrecord.service.type.PRISONER_CREATED
 import uk.gov.justice.digital.hmpps.personrecord.test.randomCrn
 import uk.gov.justice.digital.hmpps.personrecord.test.randomLowerCaseString
 
@@ -122,25 +120,29 @@ class ProbationAddressUpdatedEventListenerIntTest : ProbationEventListenerTestBa
   }
 
   @Test
-  fun `check for event source on sas update event`() {
+  fun `consuming address updated event - cpr event source - does not update address or publish subsequent events`() {
     val originalProbationAddress = randomProbationAddress()
     val personEntity = createPersonWithNewKey(
       createRandomProbationPersonDetails().copy(addresses = listOf(Address.from(originalProbationAddress)!!)),
     )
     val cprAddressBeforeUpdate = personEntity.addresses.first()
 
-   // val updatedProbationAddress = randomProbationAddress().copy(deliusAddressId = cprAddressBeforeUpdate.deliusAddressId)
-
-    publishProbationAddressEvent(personEntity.crn,
+    publishProbationAddressEvent(
+      personEntity.crn,
       personEntity.addresses[0].deliusAddressId,
       OFFENDER_ADDRESS_UPDATED,
-      CPR
+      CPR,
     )
 
-
-
     val actualPersonEntity = awaitNotNull { personRepository.findByCrn(personEntity.crn!!) }
-    assertThat(actualPersonEntity).isEqualTo(personEntity)
+    assertThat(actualPersonEntity.addresses.size).isEqualTo(1)
+    val cprAddressAfterUpdate = actualPersonEntity.addresses.first()
+    assertThat(cprAddressAfterUpdate.id).isEqualTo(cprAddressBeforeUpdate.id)
+    assertThat(cprAddressAfterUpdate.updateId).isEqualTo(cprAddressBeforeUpdate.updateId)
 
+    expectNoMessagesOn(testOnlyCPRDomainEventsQueue)
+    wiremock.verify(0, getRequestedFor(urlEqualTo("/address/*")))
+    wiremock.verify(0, postRequestedFor(urlEqualTo("/person")))
+    wiremock.verify(0, getRequestedFor(urlEqualTo("/person/score/.*")))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationAddressUpdatedEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationAddressUpdatedEventListenerIntTest.kt
@@ -6,9 +6,12 @@ import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Address
+import uk.gov.justice.digital.hmpps.personrecord.service.DomainEventSource
+import uk.gov.justice.digital.hmpps.personrecord.service.DomainEventSource.CPR
 import uk.gov.justice.digital.hmpps.personrecord.service.type.CPR_PROBATION_ADDRESS_CREATED
 import uk.gov.justice.digital.hmpps.personrecord.service.type.CPR_PROBATION_ADDRESS_UPDATED
 import uk.gov.justice.digital.hmpps.personrecord.service.type.OFFENDER_ADDRESS_UPDATED
+import uk.gov.justice.digital.hmpps.personrecord.service.type.PRISONER_CREATED
 import uk.gov.justice.digital.hmpps.personrecord.test.randomCrn
 import uk.gov.justice.digital.hmpps.personrecord.test.randomLowerCaseString
 
@@ -116,5 +119,28 @@ class ProbationAddressUpdatedEventListenerIntTest : ProbationEventListenerTestBa
       expectedEventType = CPR_PROBATION_ADDRESS_CREATED,
       crn = personEntity.crn!!,
     )
+  }
+
+  @Test
+  fun `check for event source on sas update event`() {
+    val originalProbationAddress = randomProbationAddress()
+    val personEntity = createPersonWithNewKey(
+      createRandomProbationPersonDetails().copy(addresses = listOf(Address.from(originalProbationAddress)!!)),
+    )
+    val cprAddressBeforeUpdate = personEntity.addresses.first()
+
+   // val updatedProbationAddress = randomProbationAddress().copy(deliusAddressId = cprAddressBeforeUpdate.deliusAddressId)
+
+    publishProbationAddressEvent(personEntity.crn,
+      personEntity.addresses[0].deliusAddressId,
+      OFFENDER_ADDRESS_UPDATED,
+      CPR
+    )
+
+
+
+    val actualPersonEntity = awaitNotNull { personRepository.findByCrn(personEntity.crn!!) }
+    assertThat(actualPersonEntity).isEqualTo(personEntity)
+
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListenerTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListenerTestBase.kt
@@ -94,7 +94,7 @@ class ProbationEventListenerTestBase : MessagingMultiNodeTestBase() {
     )
   }
 
-  fun publishProbationAddressEvent(crn: String?, probationAddressId: Long?, eventType: String) {
+  fun publishProbationAddressEvent(crn: String?, probationAddressId: Long?, eventType: String, eventSource: DomainEventSource? = null) {
     publishDomainEvent(
       eventType,
       DomainEvent(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListenerTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListenerTestBase.kt
@@ -94,7 +94,7 @@ class ProbationEventListenerTestBase : MessagingMultiNodeTestBase() {
     )
   }
 
-  fun publishProbationAddressEvent(crn: String?, probationAddressId: Long?, eventType: String, eventSource: DomainEventSource? = null) {
+  fun publishProbationAddressEvent(crn: String?, probationAddressId: Long?, eventType: String, eventSource: DomainEventSource? = DELIUS) {
     publishDomainEvent(
       eventType,
       DomainEvent(
@@ -103,6 +103,7 @@ class ProbationEventListenerTestBase : MessagingMultiNodeTestBase() {
         additionalInformation = AdditionalInformation(inboundDeliusAddressId = probationAddressId.toString()),
         personReference = PersonReference(listOf(PersonIdentifier("CRN", crn!!))),
       ),
+      eventSource,
     )
   }
 


### PR DESCRIPTION
# 🚨 READ THIS 🚨

Does this change...
* [ ] 🔨 Have any downstream breaking changes
* [ ] 🚩 Need Feature flagged
* [ ] 🔀 Require any database migrations
* [ ] 🔔 Alerting of any other teams of changes
* [ ] ☁️ Need to provision/update any cloud platform resources
* [ ] ⚡️ Benefit from running the [load tests](https://github.com/ministryofjustice/hmpps-person-record-gatling)
