### PR TITLE
CPR-1167 test function changes to accommodate delete events when they come

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationAddressCreatedEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationAddressCreatedEventListenerIntTest.kt
@@ -23,10 +23,11 @@ class ProbationAddressCreatedEventListenerIntTest : ProbationEventListenerTestBa
 
     publishProbationAddressEvent(cprPerson.crn, probationAddress.deliusAddressId, OFFENDER_ADDRESS_CREATED)
 
-    assertAddress(cprPerson.crn!!, probationAddress)
+    val actualAddress = assertAddress(cprPerson.crn!!, probationAddress)
     assertDomainEventPublishedAfterDeliusEvent(
       expectedEventType = CPR_PROBATION_ADDRESS_CREATED,
       crn = cprPerson.crn,
+      cprAddressUpdateId = actualAddress.updateId.toString(),
     )
   }
 
@@ -50,11 +51,12 @@ class ProbationAddressCreatedEventListenerIntTest : ProbationEventListenerTestBa
     val addressEntityAfterCreateEvent = actualPersonEntity.addresses.first()
     assertThat(addressEntityAfterCreateEvent.id).isEqualTo(addressEntityBeforeCreateEvent.id)
     assertThat(addressEntityAfterCreateEvent.updateId).isEqualTo(addressEntityBeforeCreateEvent.updateId)
-    assertAddress(personEntity.crn!!, updatedProbationAddress)
 
+    val actualAddress = assertAddress(personEntity.crn!!, updatedProbationAddress)
     assertDomainEventPublishedAfterDeliusEvent(
       expectedEventType = CPR_PROBATION_ADDRESS_UPDATED,
       crn = personEntity.crn!!,
+      cprAddressUpdateId = actualAddress.updateId.toString(),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationAddressUpdatedEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationAddressUpdatedEventListenerIntTest.kt
@@ -35,9 +35,12 @@ class ProbationAddressUpdatedEventListenerIntTest : ProbationEventListenerTestBa
     assertThat(cprAddressAfterUpdate.id).isEqualTo(cprAddressBeforeUpdate.id)
     assertThat(cprAddressAfterUpdate.updateId).isEqualTo(cprAddressBeforeUpdate.updateId)
     assertAddress(personEntity.crn!!, updatedProbationAddress)
+
+    val actualAddress = assertAddress(personEntity.crn!!, updatedProbationAddress)
     assertDomainEventPublishedAfterDeliusEvent(
       expectedEventType = CPR_PROBATION_ADDRESS_UPDATED,
       crn = personEntity.crn!!,
+      cprAddressUpdateId = actualAddress.updateId.toString(),
     )
   }
 
@@ -111,10 +114,12 @@ class ProbationAddressUpdatedEventListenerIntTest : ProbationEventListenerTestBa
 
     val actualPersonEntity = awaitNotNull { personRepository.findByCrn(personEntity.crn!!) }
     assertThat(actualPersonEntity.addresses.size).isEqualTo(1)
-    assertAddress(personEntity.crn!!, probationAddress)
+
+    val actualAddress = assertAddress(personEntity.crn!!, probationAddress)
     assertDomainEventPublishedAfterDeliusEvent(
       expectedEventType = CPR_PROBATION_ADDRESS_CREATED,
       crn = personEntity.crn!!,
+      cprAddressUpdateId = actualAddress.updateId.toString(),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListenerTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListenerTestBase.kt
@@ -107,11 +107,12 @@ class ProbationEventListenerTestBase : MessagingMultiNodeTestBase() {
     )
   }
 
-  fun assertAddress(crn: String, probationAddress: ProbationAddress) {
+  fun assertAddress(crn: String, probationAddress: ProbationAddress): AddressEntity {
+    var actualAddressEntity: AddressEntity? = null
     awaitAssert {
       val actualPersonEntity = personRepository.findByCrn(crn)!!
       assertThat(actualPersonEntity.addresses.size).isEqualTo(1)
-      val actualAddressEntity = actualPersonEntity.addresses.first()
+      actualAddressEntity = actualPersonEntity.addresses.first()
       assertThat(actualAddressEntity.updateId).isNotNull()
       assertThat(actualAddressEntity.updateId!!.toString()).isNotBlank
       assertThat(actualAddressEntity.noFixedAbode).isEqualTo(probationAddress.noFixedAbode)
@@ -134,22 +135,23 @@ class ProbationEventListenerTestBase : MessagingMultiNodeTestBase() {
       assertThat(actualAddressEntity.contacts.first().contactType).isEqualTo(ContactType.HOME)
       assertThat(actualAddressEntity.contacts.first().contactValue).isEqualTo(probationAddress.telephoneNumber)
     }
+    return actualAddressEntity!!
   }
 
-  fun assertDomainEventPublishedAfterDeliusEvent(expectedEventType: String, crn: String) {
-    val (addressEntity, domainEvent: DomainEvent) = checkDomainEventPublished(crn, expectedEventType, DELIUS)
-    assertThat(domainEvent.additionalInformation?.outboundDeliusAddressId).isEqualTo(addressEntity.deliusAddressId)
+  fun assertDomainEventPublishedAfterDeliusEvent(expectedEventType: String, crn: String, cprAddressUpdateId: String) {
+    val (addressEntity, domainEvent: DomainEvent) = checkDomainEventPublished(crn, expectedEventType, cprAddressUpdateId, DELIUS)
+    assertThat(domainEvent.additionalInformation?.outboundDeliusAddressId).isEqualTo(addressEntity!!.deliusAddressId)
   }
 
-  fun assertDomainEventPublishedAfterSasEvent(expectedEventType: String, crn: String) = checkDomainEventPublished(crn, expectedEventType, CPR)
+  fun assertDomainEventPublishedAfterSasEvent(expectedEventType: String, crn: String, cprAddressUpdateId: String) = checkDomainEventPublished(crn, expectedEventType, cprAddressUpdateId, CPR)
 
   private fun checkDomainEventPublished(
     crn: String,
     expectedEventType: String,
+    cprAddressUpdateId: String,
     eventSource: DomainEventSource,
-  ): Pair<AddressEntity, DomainEvent> {
+  ): Pair<AddressEntity?, DomainEvent> {
     val actualPersonEntity = awaitNotNull { personRepository.findByCrn(crn) }
-    assertThat(actualPersonEntity.addresses.size).isEqualTo(1)
     val addressEntity = actualPersonEntity.addresses.first()
 
     expectOneMessageOn(testOnlyCPRDomainEventsQueue)
@@ -168,7 +170,7 @@ class ProbationEventListenerTestBase : MessagingMultiNodeTestBase() {
     assertThat(domainEvent.occurredAt).isNotNull()
     assertThat(domainEvent.personReference?.identifiers?.size).isEqualTo(1)
     assertThat(domainEvent.getCrn()).isEqualTo(crn)
-    assertThat(domainEvent.additionalInformation?.outboundCprAddressId).isEqualTo(addressEntity.updateId.toString())
+    assertThat(domainEvent.additionalInformation?.outboundCprAddressId).isEqualTo(cprAddressUpdateId)
     return Pair(addressEntity, domainEvent)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/sas/SasAddressUpdatedEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/sas/SasAddressUpdatedEventListenerIntTest.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.personrecord.client.model.sas.SasAddressType
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sas.SasGetAddressResponse
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.DomainEvent
 import uk.gov.justice.digital.hmpps.personrecord.extensions.toUkLocalDate
+import uk.gov.justice.digital.hmpps.personrecord.jpa.entity.AddressEntity
 import uk.gov.justice.digital.hmpps.personrecord.message.listeners.probation.ProbationEventListenerTestBase
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Address
 import uk.gov.justice.digital.hmpps.personrecord.service.DomainEventSource
@@ -65,9 +66,12 @@ class SasAddressUpdatedEventListenerIntTest : ProbationEventListenerTestBase() {
       publishSasAddressUpdateEvent()
 
       assertAddressUpdated(crn, sasCallbackResponse, deliusAddressId)
+
+      val actualAddress = assertAddressUpdated(crn, sasCallbackResponse, deliusAddressId)
       assertDomainEventPublishedAfterSasEvent(
         expectedEventType = CPR_PROBATION_ADDRESS_UPDATED,
         crn = crn!!,
+        cprAddressUpdateId = actualAddress.updateId.toString(),
       )
     }
   }
@@ -183,12 +187,13 @@ class SasAddressUpdatedEventListenerIntTest : ProbationEventListenerTestBase() {
     )
   }
 
-  private fun assertAddressUpdated(crn: String?, expected: SasGetAddressResponse, existingDeliusAddressId: Long) {
+  private fun assertAddressUpdated(crn: String?, expected: SasGetAddressResponse, existingDeliusAddressId: Long): AddressEntity {
+    var actualAddressEntity: AddressEntity? = null
     awaitAssert {
       val expectedSasAddress = expected.data
       val actualPersonEntity = personRepository.findByCrn(crn!!)!!
       assertThat(actualPersonEntity.addresses.size).isEqualTo(1)
-      val actualAddressEntity = actualPersonEntity.addresses.first()
+      actualAddressEntity = actualPersonEntity.addresses.first()
 
       assertThat(actualAddressEntity.postcode).isEqualTo(expectedSasAddress.address.postcode)
       assertThat(actualAddressEntity.deliusAddressId).isEqualTo(existingDeliusAddressId)
@@ -210,5 +215,6 @@ class SasAddressUpdatedEventListenerIntTest : ProbationEventListenerTestBase() {
       assertThat(actualAddressUsages.first().usageCode.name).isEqualTo(expectedSasAddress.usage!!.code)
       assertThat(actualAddressUsages.first().active).isEqualTo(true)
     }
+    return actualAddressEntity!!
   }
 }


### PR DESCRIPTION
…come

# 🚨 READ THIS 🚨

Does this change...
* [ ] 🔨 Have any downstream breaking changes
* [ ] 🚩 Need Feature flagged
* [ ] 🔀 Require any database migrations
* [ ] 🔔 Alerting of any other teams of changes
* [ ] ☁️ Need to provision/update any cloud platform resources
* [ ] ⚡️ Benefit from running the [load tests](https://github.com/ministryofjustice/hmpps-person-record-gatling)
