### PR TITLE
CPR-1201 Fix flaky assert when checking published CPR events

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListenerTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListenerTestBase.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.personrecord.client.model.sas.SasAddressStat
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sas.SasAddressType
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sas.SasGetAddressResponse
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.MessageAttribute
+import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.SQSMessage
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.CprAddressCreated
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.CprAddressDeleted
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.CprAddressUpdated
@@ -280,7 +281,32 @@ class ProbationEventListenerTestBase : MessagingMultiNodeTestBase() {
   }
 
   fun assertCprAddressUpdatedEventPublished(crn: String, cprAddressId: UUID, deliusAddressId: Long?, eventSource: DomainEventSource) {
-    val sqsMessage = receiveNextMessageOnQueue(testOnlyCPRDomainEventsQueue)
+    assertCprAddressUpdatedEvent(receiveNextMessageOnQueue(testOnlyCPRDomainEventsQueue), crn, cprAddressId, deliusAddressId, eventSource)
+  }
+
+  data class CprAddressUpdatedEventExpected(
+    val crn: String,
+    val cprAddressId: UUID,
+    val deliusAddressId: Long?,
+    val eventSource: DomainEventSource,
+  )
+
+  fun assertCprAddressUpdatedEventsPublished(vararg expected: CprAddressUpdatedEventExpected) {
+    val messages = List(expected.size) { receiveNextMessageOnQueue(testOnlyCPRDomainEventsQueue) }.toMutableList()
+    expected.forEach { expectation ->
+      val match = messages.firstOrNull { message ->
+        message.getEventType() == CPR_PROBATION_ADDRESS_UPDATED &&
+          jsonMapper.readValue<CprAddressUpdated>(message.message).additionalInformation.cprAddressId == expectation.cprAddressId
+      }
+      assertThat(match)
+        .withFailMessage("No CPR address updated event found for cprAddressId ${expectation.cprAddressId}")
+        .isNotNull()
+      messages.remove(match)
+      assertCprAddressUpdatedEvent(match!!, expectation.crn, expectation.cprAddressId, expectation.deliusAddressId, expectation.eventSource)
+    }
+  }
+
+  private fun assertCprAddressUpdatedEvent(sqsMessage: SQSMessage, crn: String, cprAddressId: UUID, deliusAddressId: Long?, eventSource: DomainEventSource) {
     assertThat(sqsMessage.getEventType()).isEqualTo(CPR_PROBATION_ADDRESS_UPDATED)
     assertThat(sqsMessage.messageAttributes?.eventSource).isEqualTo(MessageAttribute(eventSource.identifier))
     val domainEvent: CprAddressUpdated = jsonMapper.readValue<CprAddressUpdated>(sqsMessage.message)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListenerTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListenerTestBase.kt
@@ -291,18 +291,18 @@ class ProbationEventListenerTestBase : MessagingMultiNodeTestBase() {
     val eventSource: DomainEventSource,
   )
 
-  fun assertCprAddressUpdatedEventsPublished(vararg expected: ExpectedCprAddressUpdatedEvent) {
-    val messages = List(expected.size) { receiveNextMessageOnQueue(testOnlyCPRDomainEventsQueue) }.toMutableList()
-    expected.forEach { expectation ->
+  fun assertCprAddressUpdatedEventsPublished(vararg expectedEvents: ExpectedCprAddressUpdatedEvent) {
+    val messages = List(expectedEvents.size) { receiveNextMessageOnQueue(testOnlyCPRDomainEventsQueue) }.toMutableList()
+    expectedEvents.forEach { expectedEvent ->
       val match = messages.firstOrNull { message ->
         message.getEventType() == CPR_PROBATION_ADDRESS_UPDATED &&
-          jsonMapper.readValue<CprAddressUpdated>(message.message).additionalInformation.cprAddressId == expectation.cprAddressId
+          jsonMapper.readValue<CprAddressUpdated>(message.message).additionalInformation.cprAddressId == expectedEvent.cprAddressId
       }
       assertThat(match)
-        .withFailMessage("No CPR address updated event found for cprAddressId ${expectation.cprAddressId}")
+        .withFailMessage("No CPR address updated event found for cprAddressId ${expectedEvent.cprAddressId}")
         .isNotNull()
       messages.remove(match)
-      assertCprAddressUpdatedEvent(match!!, expectation.crn, expectation.cprAddressId, expectation.deliusAddressId, expectation.eventSource)
+      assertCprAddressUpdatedEvent(match!!, expectedEvent.crn, expectedEvent.cprAddressId, expectedEvent.deliusAddressId, expectedEvent.eventSource)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListenerTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationEventListenerTestBase.kt
@@ -284,14 +284,14 @@ class ProbationEventListenerTestBase : MessagingMultiNodeTestBase() {
     assertCprAddressUpdatedEvent(receiveNextMessageOnQueue(testOnlyCPRDomainEventsQueue), crn, cprAddressId, deliusAddressId, eventSource)
   }
 
-  data class CprAddressUpdatedEventExpected(
+  data class ExpectedCprAddressUpdatedEvent(
     val crn: String,
     val cprAddressId: UUID,
     val deliusAddressId: Long?,
     val eventSource: DomainEventSource,
   )
 
-  fun assertCprAddressUpdatedEventsPublished(vararg expected: CprAddressUpdatedEventExpected) {
+  fun assertCprAddressUpdatedEventsPublished(vararg expected: ExpectedCprAddressUpdatedEvent) {
     val messages = List(expected.size) { receiveNextMessageOnQueue(testOnlyCPRDomainEventsQueue) }.toMutableList()
     expected.forEach { expectation ->
       val match = messages.firstOrNull { message ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/sas/SasAddressArrivedEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/sas/SasAddressArrivedEventListenerIntTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.personrecord.message.listeners.sas
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sas.SasAddressStatus
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sas.SasGetAddressResponse
@@ -51,7 +50,7 @@ class SasAddressArrivedEventListenerIntTest : ProbationEventListenerTestBase() {
       assertCprAddressUpdatedEventPublished(personEntity.crn!!, originalAddressEntity.updateId!!, originalAddressEntity.deliusAddressId, CPR)
     }
 
-    @RepeatedTest(100)
+    @Test
     fun `existing main address is set to previous and incoming address is now main`() {
       val crn = randomCrn()
       createPersonKey().addPerson(
@@ -85,8 +84,8 @@ class SasAddressArrivedEventListenerIntTest : ProbationEventListenerTestBase() {
       }
 
       assertCprAddressUpdatedEventsPublished(
-        CprAddressUpdatedEventExpected(personEntity.crn!!, originalMainAddress.updateId!!, originalMainAddress.deliusAddressId, CPR),
-        CprAddressUpdatedEventExpected(personEntity.crn!!, proposedAddress.updateId!!, proposedAddress.deliusAddressId, CPR),
+        ExpectedCprAddressUpdatedEvent(personEntity.crn!!, originalMainAddress.updateId!!, originalMainAddress.deliusAddressId, CPR),
+        ExpectedCprAddressUpdatedEvent(personEntity.crn!!, proposedAddress.updateId!!, proposedAddress.deliusAddressId, CPR),
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/sas/SasAddressArrivedEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/sas/SasAddressArrivedEventListenerIntTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.personrecord.message.listeners.sas
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sas.SasAddressStatus
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sas.SasGetAddressResponse
@@ -50,7 +51,7 @@ class SasAddressArrivedEventListenerIntTest : ProbationEventListenerTestBase() {
       assertCprAddressUpdatedEventPublished(personEntity.crn!!, originalAddressEntity.updateId!!, originalAddressEntity.deliusAddressId, CPR)
     }
 
-    @Test
+    @RepeatedTest(100)
     fun `existing main address is set to previous and incoming address is now main`() {
       val crn = randomCrn()
       createPersonKey().addPerson(
@@ -83,8 +84,10 @@ class SasAddressArrivedEventListenerIntTest : ProbationEventListenerTestBase() {
         assertThat(newMainAddress.startDate!!.toUkLocalDate()).isEqualTo(sasCallbackResponse.startDate)
       }
 
-      assertCprAddressUpdatedEventPublished(personEntity.crn!!, originalMainAddress.updateId!!, originalMainAddress.deliusAddressId, CPR)
-      assertCprAddressUpdatedEventPublished(personEntity.crn!!, proposedAddress.updateId!!, proposedAddress.deliusAddressId, CPR)
+      assertCprAddressUpdatedEventsPublished(
+        CprAddressUpdatedEventExpected(personEntity.crn!!, originalMainAddress.updateId!!, originalMainAddress.deliusAddressId, CPR),
+        CprAddressUpdatedEventExpected(personEntity.crn!!, proposedAddress.updateId!!, proposedAddress.deliusAddressId, CPR),
+      )
     }
 
     @Test


### PR DESCRIPTION
# 🚨 READ THIS 🚨

Does this change...
* [ ] 🔨 Have any downstream breaking changes
* [ ] 🚩 Need Feature flagged
* [ ] 🔀 Require any database migrations
* [ ] 🔔 Alerting of any other teams of changes
* [ ] ☁️ Need to provision/update any cloud platform resources
* [ ] ⚡️ Benefit from running the [load tests](https://github.com/ministryofjustice/hmpps-person-record-gatling)
