### PR TITLE
FIX: make less use of createPersonKey method

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/jobs/ServiceNowMergeRequestE2ETest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/jobs/ServiceNowMergeRequestE2ETest.kt
@@ -238,12 +238,10 @@ class ServiceNowMergeRequestE2ETest : E2ETestBase() {
 
   @Test
   fun `should ignore merged records`() {
-    val person1 = createPerson(createRandomProbationPersonDetails())
-    val person2 = createPerson(createRandomProbationPersonDetails())
-    createPersonKey()
-      .addPerson(person1)
-    createPersonKey()
-      .addPerson(person2)
+    val person1 = createRandomProbationPersonDetails()
+    val person2 = createRandomProbationPersonDetails()
+    createPersonWithNewKey(person1)
+    createPersonWithNewKey(person2)
 
     val person3 = createRandomProbationPersonDetails()
     val person4 = createRandomProbationPersonDetails()
@@ -261,8 +259,8 @@ class ServiceNowMergeRequestE2ETest : E2ETestBase() {
     )
     val tenHoursAgo = LocalDateTime.now().minusHours(HOURS_TO_CHOOSE_FROM)
 
-    personRepository.updateLastModifiedDate(person1.crn!!, tenHoursAgo.plusMinutes(1))
-    personRepository.updateLastModifiedDate(person2.crn!!, tenHoursAgo.plusMinutes(2))
+    personRepository.updateLastModifiedDate(person1.crn, tenHoursAgo.plusMinutes(1))
+    personRepository.updateLastModifiedDate(person2.crn, tenHoursAgo.plusMinutes(2))
     personRepository.updateLastModifiedDate(person3.crn!!, tenHoursAgo.plusMinutes(2))
     personRepository.updateLastModifiedDate(person4.crn!!, tenHoursAgo.plusMinutes(2))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/court/commonplatform/CommonPlatformCourtEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/court/commonplatform/CommonPlatformCourtEventListenerIntTest.kt
@@ -60,7 +60,6 @@ import uk.gov.justice.digital.hmpps.personrecord.test.randomNationalInsuranceNum
 import uk.gov.justice.digital.hmpps.personrecord.test.randomPostcode
 import uk.gov.justice.digital.hmpps.personrecord.test.randomTitleCode
 import java.nio.charset.Charset
-import java.time.LocalDateTime.now
 import java.util.UUID
 
 class CommonPlatformCourtEventListenerIntTest : MessagingMultiNodeTestBase() {
@@ -119,7 +118,6 @@ class CommonPlatformCourtEventListenerIntTest : MessagingMultiNodeTestBase() {
     val defendantId = randomDefendantId()
     val pnc = randomLongPnc()
     val cro = randomCro()
-    val personKey = createPersonKey()
     val ethnicity = randomCommonPlatformEthnicity()
 
     val person = Person(
@@ -128,20 +126,17 @@ class CommonPlatformCourtEventListenerIntTest : MessagingMultiNodeTestBase() {
       sourceSystem = COMMON_PLATFORM,
     )
 
-    val personEntity = PersonEntity(
-      defendantId = person.defendantId,
-      crn = person.crn,
-      prisonNumber = person.prisonNumber,
-      masterDefendantId = person.masterDefendantId,
-      sourceSystem = person.sourceSystem,
-      religion = person.religion,
-      matchId = UUID.randomUUID(),
-      cId = person.cId,
-      lastModified = now(),
+    val personEntity = createPersonWithNewKey(
+      Person(
+        defendantId = person.defendantId,
+        crn = person.crn,
+        prisonNumber = person.prisonNumber,
+        masterDefendantId = person.masterDefendantId,
+        sourceSystem = person.sourceSystem,
+        religion = person.religion,
+        cId = person.cId,
+      ),
     )
-    personEntity.personKey = personKey
-    personKeyRepository.saveAndFlush(personKey)
-    personRepository.saveAndFlush(personEntity)
     stubNoMatchesPersonMatch(matchId = personEntity.matchId)
 
     val changedLastName = randomName()


### PR DESCRIPTION
# 🚨 READ THIS 🚨

Does this change...
* [ ] 🔨 Have any downstream breaking changes
* [ ] 🚩 Need Feature flagged
* [ ] 🔀 Require any database migrations
* [ ] 🔔 Alerting of any other teams of changes
* [ ] ☁️ Need to provision/update any cloud platform resources
* [ ] ⚡️ Benefit from running the [load tests](https://github.com/ministryofjustice/hmpps-person-record-gatling)
