### PR TITLE
Remove deliusAddressId elements from AddressBuilder.kt

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/entity/builder/AddressBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/jpa/entity/builder/AddressBuilder.kt
@@ -20,12 +20,5 @@ object AddressBuilder {
     )
   }
 
-  // Once the final work around changing how we consume probation address
-  // is done, this can be reverted back
-  private fun Address.matches(entity: AddressEntity): Boolean {
-    if (entity.deliusAddressId != null) {
-      return entity.deliusAddressId == this.deliusAddressId
-    }
-    return this == Address.from(entity)
-  }
+  private fun Address.matches(entity: AddressEntity): Boolean = this == Address.from(entity)
 }


### PR DESCRIPTION
This is not needed as Delius addresses no longer go down this path.

# 🚨 READ THIS 🚨

Does this change...
* [ ] 🔨 Have any downstream breaking changes
* [ ] 🚩 Need Feature flagged
* [ ] 🔀 Require any database migrations
* [ ] 🔔 Alerting of any other teams of changes
* [ ] ☁️ Need to provision/update any cloud platform resources
* [ ] ⚡️ Benefit from running the [load tests](https://github.com/ministryofjustice/hmpps-person-record-gatling)
