### PR TITLE
Remove datafeed url

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,10 +13,6 @@ plugins {
   id("org.owasp.dependencycheck") version "12.2.2"
 }
 
-dependencyCheck {
-  nvd.datafeedUrl = "file:///opt/vulnz/cache"
-}
-
 configurations {
   testImplementation { exclude(group = "org.junit.vintage") }
 }


### PR DESCRIPTION
Attempting to fix the OWASP GitHub action. This is a suggestion from hmpps-digital-sre.

# 🚨 READ THIS 🚨

Does this change...
* [ ] 🔨 Have any downstream breaking changes
* [ ] 🚩 Need Feature flagged
* [ ] 🔀 Require any database migrations
* [ ] 🔔 Alerting of any other teams of changes
* [ ] ☁️ Need to provision/update any cloud platform resources
* [ ] ⚡️ Benefit from running the [load tests](https://github.com/ministryofjustice/hmpps-person-record-gatling)
