### PR TITLE
CPR-1236 Handle missing Delius addresses in address usage migration

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/admin/RetryableAddressMigrator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/admin/RetryableAddressMigrator.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.personrecord.api.controller.admin
 
 import jakarta.persistence.OptimisticLockException
+import org.slf4j.LoggerFactory
 import org.springframework.dao.CannotAcquireLockException
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
@@ -10,6 +11,7 @@ import uk.gov.justice.digital.hmpps.personrecord.client.CorePersonRecordAndDeliu
 import uk.gov.justice.digital.hmpps.personrecord.jpa.repository.AddressRepository
 import uk.gov.justice.digital.hmpps.personrecord.service.DomainEventSource.DELIUS
 import uk.gov.justice.digital.hmpps.personrecord.service.address.AddressService
+import uk.gov.justice.digital.hmpps.personrecord.service.queue.DiscardableNotFoundException
 
 @Service
 class RetryableAddressMigrator(
@@ -27,11 +29,20 @@ class RetryableAddressMigrator(
     ],
   )
   fun migrateUsage(deliusAddressId: Long) {
-    val deliusAddress = corePersonRecordAndDeliusClient.getAddress(deliusAddressId)
-    addressService.processAddress(
-      address = deliusAddress!!,
-      findAddress = { addressRepository.findByDeliusAddressId(deliusAddressId) },
-      eventSource = DELIUS,
-    )
+    try {
+      corePersonRecordAndDeliusClient.getAddressIgnoreNotFound(deliusAddressId)?.let {
+        addressService.processAddress(
+          address = it,
+          findAddress = { addressRepository.findByDeliusAddressId(deliusAddressId) },
+          eventSource = DELIUS,
+        )
+      }
+    } catch (_: DiscardableNotFoundException) {
+      log.info("Address with deliusAddressId $deliusAddressId not found in Delius, discarding")
+    }
+  }
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/CorePersonRecordAndDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/CorePersonRecordAndDeliusClient.kt
@@ -38,6 +38,16 @@ class CorePersonRecordAndDeliusClient(private val corePersonRecordAndDeliusWebCl
     .retrieve()
     .bodyToMono<ProbationCase>()
 
+  fun getAddressIgnoreNotFound(deliusAddressId: Long): Address? = Address.from(
+    corePersonRecordAndDeliusWebClient
+      .get()
+      .uri("/address/{id}", deliusAddressId)
+      .retrieve()
+      .bodyToMono<ProbationAddress>()
+      .discardNotFoundException()
+      .block()!!,
+  )
+
   fun getAddress(deliusAddressId: Long): Address? = Address.from(
     corePersonRecordAndDeliusWebClient
       .get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/admin/MigrateUnknownAddressUsageCodesControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/admin/MigrateUnknownAddressUsageCodesControllerIntTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.personrecord.model.person.Person
 import uk.gov.justice.digital.hmpps.personrecord.model.types.AddressUsageCode.UNKNOWN
 import uk.gov.justice.digital.hmpps.personrecord.test.randomAddressUsageCode
 import uk.gov.justice.digital.hmpps.personrecord.test.randomBoolean
+import uk.gov.justice.digital.hmpps.personrecord.test.randomCrn
 import uk.gov.justice.digital.hmpps.personrecord.test.randomDeliusAddressId
 import uk.gov.justice.digital.hmpps.personrecord.test.randomPostcode
 import uk.gov.justice.digital.hmpps.personrecord.test.responses.ApiResponseSetupAddress
@@ -30,6 +31,94 @@ class MigrateUnknownAddressUsageCodesControllerIntTest : WebTestBase() {
 
   @Nested
   inner class ErrorRecovery {
+    @Test
+    fun `should bypass address update of 404 error`() {
+      val probationCase = createRandomProbationCase()
+      val deliusAddressId1 = randomDeliusAddressId()
+      val deliusAddressId2 = randomDeliusAddressId()
+      val postcode = randomPostcode()
+      createPersonWithNewKey(
+        Person.from(probationCase),
+        configure = addAddressToRecord(Address(postcode = postcode, deliusAddressId = deliusAddressId1, usages = listOf(AddressUsage(UNKNOWN, randomBoolean()))))
+      )
+      createPersonWithNewKey(
+        Person.from(probationCase).copy(crn = randomCrn()),
+        configure = addAddressToRecord(Address(postcode = postcode, deliusAddressId = deliusAddressId2, usages = listOf(AddressUsage(UNKNOWN, randomBoolean()))))
+      )
+
+      val usageCode = randomAddressUsageCode()
+
+      val probationAddress1 = ProbationAddress(
+        postcode = postcode,
+        deliusAddressId = deliusAddressId1,
+        usage = ProbationAddressUsage(
+          code = usageCode.name,
+          description = usageCode.description,
+        ),
+      )
+
+      val probationAddress2 = ProbationAddress(
+        postcode = postcode,
+        deliusAddressId = deliusAddressId2,
+        usage = ProbationAddressUsage(
+          code = usageCode.name,
+          description = usageCode.description,
+        ),
+      )
+
+      stubGetRequest(
+        url = "/address/${probationAddress1.deliusAddressId}",
+        status = 404,
+        body = "",
+        scenarioName = "Skip 404 and continue with next address",
+        nextScenarioState = "Request will Pass",
+      )
+
+      stubGetRequest(
+        url = "/address/${probationAddress2.deliusAddressId}",
+        scenarioName = "Skip 404 and continue with next address",
+        currentScenarioState = "Request will Pass",
+        body = probationAddress(
+          address = ApiResponseSetupAddress(
+            noFixedAbode = probationAddress2.noFixedAbode,
+            startDateTime = probationAddress2.startDateTime,
+            endDateTime = probationAddress2.endDateTime,
+            postcode = probationAddress2.postcode,
+            fullAddress = probationAddress2.fullAddress,
+            buildingName = probationAddress2.buildingName,
+            addressNumber = probationAddress2.addressNumber,
+            streetName = probationAddress2.streetName,
+            district = probationAddress2.district,
+            townCity = probationAddress2.townCity,
+            county = probationAddress2.county,
+            deliusAddressId = probationAddress2.deliusAddressId!!,
+            isVerified = probationAddress2.isVerified,
+            status = ApiResponseSetupAddressStatus(
+              probationAddress2.status?.code,
+              probationAddress2.status?.description,
+            ),
+            usage = ApiResponseSetupAddressUsage(probationAddress2.usage?.code, probationAddress2.usage?.description),
+            uprn = probationAddress2.uprn,
+            notes = probationAddress2.notes,
+            telephoneNumber = probationAddress2.telephoneNumber,
+          ),
+        ),
+      )
+
+      sendPostRequestAsserted<String>(
+        url = "/admin/migrate-unknown-address-usage-codes",
+        body = "",
+        expectedStatus = OK,
+        sendAuthorised = false,
+        roles = listOf(),
+      ).returnResult().responseBody!!
+
+      awaitAssert {
+        assertThat(addressRepository.findByDeliusAddressId(deliusAddressId1)?.usages?.first()?.usageCode).isEqualTo(UNKNOWN)
+        assertThat(addressRepository.findByDeliusAddressId(deliusAddressId2)?.usages?.first()?.usageCode).isEqualTo(usageCode)
+      }
+    }
+
     @Test
     fun `should retry on HTTP error`() {
       val probationCase = createRandomProbationCase()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/admin/MigrateUnknownAddressUsageCodesControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/admin/MigrateUnknownAddressUsageCodesControllerIntTest.kt
@@ -39,11 +39,11 @@ class MigrateUnknownAddressUsageCodesControllerIntTest : WebTestBase() {
       val postcode = randomPostcode()
       createPersonWithNewKey(
         Person.from(probationCase),
-        configure = addAddressToRecord(Address(postcode = postcode, deliusAddressId = deliusAddressId1, usages = listOf(AddressUsage(UNKNOWN, randomBoolean()))))
+        configure = addAddressToRecord(Address(postcode = postcode, deliusAddressId = deliusAddressId1, usages = listOf(AddressUsage(UNKNOWN, randomBoolean())))),
       )
       createPersonWithNewKey(
         Person.from(probationCase).copy(crn = randomCrn()),
-        configure = addAddressToRecord(Address(postcode = postcode, deliusAddressId = deliusAddressId2, usages = listOf(AddressUsage(UNKNOWN, randomBoolean()))))
+        configure = addAddressToRecord(Address(postcode = postcode, deliusAddressId = deliusAddressId2, usages = listOf(AddressUsage(UNKNOWN, randomBoolean())))),
       )
 
       val usageCode = randomAddressUsageCode()


### PR DESCRIPTION
We can get missing addresses on merged records.

# 🚨 READ THIS 🚨

Does this change...
* [ ] 🔨 Have any downstream breaking changes
* [ ] 🚩 Need Feature flagged
* [ ] 🔀 Require any database migrations
* [ ] 🔔 Alerting of any other teams of changes
* [ ] ☁️ Need to provision/update any cloud platform resources
* [ ] ⚡️ Benefit from running the [load tests](https://github.com/ministryofjustice/hmpps-person-record-gatling)
