### PR TITLE
CPR-1274 Amend setup of above fracture threshold data

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/E2ETestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/E2ETestBase.kt
@@ -48,6 +48,7 @@ class E2ETestBase : MessagingTestBase() {
     name = name.copy(firstName = randomName(), middleNames = randomName()),
     identifiers = this.identifiers.copy(cro = null),
     sentences = emptyList(),
+    dateOfBirth = randomDate(),
   )
 
   internal fun ProbationCase.withChangedMatchDetails(): ProbationCase = this.copy(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/E2ETestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/config/E2ETestBase.kt
@@ -45,8 +45,9 @@ class E2ETestBase : MessagingTestBase() {
   Remove matching fields to reduce match weight below the join threshold but keep above fracture threshold
    */
   internal fun ProbationCase.aboveFracture(): ProbationCase = this.copy(
-    name = name.copy(firstName = randomName()),
-    identifiers = this.identifiers.copy(pnc = null, cro = null),
+    name = name.copy(firstName = randomName(), middleNames = randomName()),
+    identifiers = this.identifiers.copy(cro = null),
+    sentences = emptyList(),
   )
 
   internal fun ProbationCase.withChangedMatchDetails(): ProbationCase = this.copy(


### PR DESCRIPTION
The matching thresholds are changing [here](https://github.com/ministryofjustice/hmpps-person-match/pull/779). As a result, some of the E2E tests that rely on being above the fracture threshold but below the join threshold no longer work. The original `match_weight` for the data was `20.6`. With this change it is now `15.5`, which means its still above the new fracture threshold of `14` but below the new join threshold of `20`.

Some of the E2E tests will fail prior to merging the [person-match PR](https://github.com/ministryofjustice/hmpps-person-match/pull/779) because the match_weight is now `15.5` which is under the existing fracture threshold of `18` meaning clusters that should've stayed together are splitting.
Once we re-run the tests with the updated person-match image the tests should pass.

# 🚨 READ THIS 🚨

Does this change...
* [ ] 🔨 Have any downstream breaking changes
* [ ] 🚩 Need Feature flagged
* [ ] 🔀 Require any database migrations
* [ ] 🔔 Alerting of any other teams of changes
* [ ] ☁️ Need to provision/update any cloud platform resources
* [ ] ⚡️ Benefit from running the [load tests](https://github.com/ministryofjustice/hmpps-person-record-gatling)
