### PR TITLE
Revert "Update plugin org.owasp.dependencycheck to v13 (#2256)"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
   kotlin("jvm") version "2.4.10"
   kotlin("plugin.jpa") version "2.4.10"
   id("org.jetbrains.kotlinx.kover") version "0.9.9"
-  id("org.owasp.dependencycheck") version "13.0.0"
+  id("org.owasp.dependencycheck") version "12.2.2"
 }
 
 configurations {


### PR DESCRIPTION
This reverts commit 2a2857736f5d70c20cac0b41eabc41ec5c813034.

# 🚨 READ THIS 🚨

Does this change...
* [ ] 🔨 Have any downstream breaking changes
* [ ] 🚩 Need Feature flagged
* [ ] 🔀 Require any database migrations
* [ ] 🔔 Alerting of any other teams of changes
* [ ] ☁️ Need to provision/update any cloud platform resources
* [ ] ⚡️ Benefit from running the [load tests](https://github.com/ministryofjustice/hmpps-person-record-gatling)
