### PR TITLE
SDIT-4058 adding the updateId to the ReligionHistory

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/prison/PrisonReligion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/prison/PrisonReligion.kt
@@ -17,6 +17,7 @@ data class PrisonReligion(
   val current: Boolean,
   val createDateTime: LocalDateTime,
   val createUserId: String,
+  val updatedId: String? = null,
 ) {
   companion object {
     fun from(prisonReligionEntity: PrisonReligionEntity): PrisonReligion = PrisonReligion(
@@ -31,6 +32,7 @@ data class PrisonReligion(
       current = prisonReligionEntity.prisonRecordType.value,
       createDateTime = prisonReligionEntity.createDateTime,
       createUserId = prisonReligionEntity.createUserId,
+      updatedId = prisonReligionEntity.updateId?.toString(),
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/prison/PrisonReligion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/prison/PrisonReligion.kt
@@ -17,7 +17,7 @@ data class PrisonReligion(
   val current: Boolean,
   val createDateTime: LocalDateTime,
   val createUserId: String,
-  val updatedId: String? = null,
+  val cprReligionId: String? = null,
 ) {
   companion object {
     fun from(prisonReligionEntity: PrisonReligionEntity): PrisonReligion = PrisonReligion(
@@ -32,7 +32,7 @@ data class PrisonReligion(
       current = prisonReligionEntity.prisonRecordType.value,
       createDateTime = prisonReligionEntity.createDateTime,
       createUserId = prisonReligionEntity.createUserId,
-      updatedId = prisonReligionEntity.updateId?.toString(),
+      cprReligionId = prisonReligionEntity.updateId?.toString(),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/prison/DpsPrisonAPIControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/prison/DpsPrisonAPIControllerIntTest.kt
@@ -186,7 +186,7 @@ class DpsPrisonAPIControllerIntTest : WebTestBase() {
       assertThat(responseBody.religionHistory.first().createUserId).isEqualTo(existingPrisonReligionEntity.createUserId)
       assertThat(responseBody.religionHistory.first().current).isEqualTo(existingPrisonReligionEntity.prisonRecordType.value)
       assertThat(responseBody.religionHistory.first().endDate).isEqualTo(existingPrisonReligionEntity.endDate)
-      assertThat(responseBody.religionHistory.first().updatedId).isEqualTo(existingPrisonReligionEntity.updateId.toString())
+      assertThat(responseBody.religionHistory.first().cprReligionId).isEqualTo(existingPrisonReligionEntity.updateId.toString())
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/prison/DpsPrisonAPIControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/controller/prison/DpsPrisonAPIControllerIntTest.kt
@@ -186,6 +186,7 @@ class DpsPrisonAPIControllerIntTest : WebTestBase() {
       assertThat(responseBody.religionHistory.first().createUserId).isEqualTo(existingPrisonReligionEntity.createUserId)
       assertThat(responseBody.religionHistory.first().current).isEqualTo(existingPrisonReligionEntity.prisonRecordType.value)
       assertThat(responseBody.religionHistory.first().endDate).isEqualTo(existingPrisonReligionEntity.endDate)
+      assertThat(responseBody.religionHistory.first().updatedId).isEqualTo(existingPrisonReligionEntity.updateId.toString())
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/prison/PrisonReligionGetResponseTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/prison/PrisonReligionGetResponseTest.kt
@@ -49,7 +49,7 @@ class PrisonReligionGetResponseTest {
         current = prisonReligionEntity.prisonRecordType.value,
         createDateTime = prisonReligionEntity.createDateTime,
         createUserId = prisonReligionEntity.createUserId,
-        updatedId = prisonReligionEntity.updateId.toString()
+        updatedId = prisonReligionEntity.updateId.toString(),
       ),
     )
     assertThat(actual).usingRecursiveComparison().isEqualTo(expected)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/prison/PrisonReligionGetResponseTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/prison/PrisonReligionGetResponseTest.kt
@@ -49,7 +49,7 @@ class PrisonReligionGetResponseTest {
         current = prisonReligionEntity.prisonRecordType.value,
         createDateTime = prisonReligionEntity.createDateTime,
         createUserId = prisonReligionEntity.createUserId,
-        updatedId = prisonReligionEntity.updateId.toString(),
+        cprReligionId = prisonReligionEntity.updateId.toString(),
       ),
     )
     assertThat(actual).usingRecursiveComparison().isEqualTo(expected)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/prison/PrisonReligionGetResponseTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/api/model/prison/PrisonReligionGetResponseTest.kt
@@ -49,6 +49,7 @@ class PrisonReligionGetResponseTest {
         current = prisonReligionEntity.prisonRecordType.value,
         createDateTime = prisonReligionEntity.createDateTime,
         createUserId = prisonReligionEntity.createUserId,
+        updatedId = prisonReligionEntity.updateId.toString()
       ),
     )
     assertThat(actual).usingRecursiveComparison().isEqualTo(expected)


### PR DESCRIPTION
Exposing the cpr id for a prisoner religion history item. We need this so that we can map the prisoner religion history items of a prison person back to the nomis religion history item. We store nomis ids to cpr ids in the mapping service. Once a merge of a person in cpr has resulted in a merge of prisoner religion history items in cpr we can use this mapping to work out what we need to update in nomis  



# 🚨 READ THIS 🚨

Does this change...
* [ ] 🔨 Have any downstream breaking changes
* [ ] 🚩 Need Feature flagged
* [ ] 🔀 Require any database migrations
* [ ] 🔔 Alerting of any other teams of changes
* [ ] ☁️ Need to provision/update any cloud platform resources
* [ ] ⚡️ Benefit from running the [load tests](https://github.com/ministryofjustice/hmpps-person-record-gatling)
