### PR TITLE
CPR-1197 Discard 404 exceptions after retries

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/CorePersonRecordAndDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/CorePersonRecordAndDeliusClient.kt
@@ -9,12 +9,15 @@ import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationAddress
 import uk.gov.justice.digital.hmpps.personrecord.client.model.offender.ProbationCase
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Address
+import uk.gov.justice.digital.hmpps.personrecord.service.queue.discardNotFoundException
 
 @Component
 class CorePersonRecordAndDeliusClient(private val corePersonRecordAndDeliusWebClient: WebClient) {
 
   @WebRetryable
-  fun getProbationCase(crn: String): ProbationCase = fetchProbationCase(crn).block()!!
+  fun getProbationCase(crn: String): ProbationCase = fetchProbationCase(crn)
+    .discardNotFoundException()
+    .block()!!
 
   @WebRetryable
   fun getAddress(deliusAddressId: Long): Address? = Address.from(
@@ -23,6 +26,7 @@ class CorePersonRecordAndDeliusClient(private val corePersonRecordAndDeliusWebCl
       .uri("/address/{id}", deliusAddressId)
       .retrieve()
       .bodyToMono<ProbationAddress>()
+      .discardNotFoundException()
       .block()!!,
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/WebRetryable.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/client/WebRetryable.kt
@@ -4,6 +4,7 @@ import org.springframework.core.annotation.AliasFor
 import org.springframework.retry.annotation.Backoff
 import org.springframework.retry.annotation.Retryable
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.personrecord.service.queue.DiscardableNotFoundException
 import kotlin.reflect.KClass
 
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
@@ -18,6 +19,7 @@ annotation class WebRetryable(
   @get:AliasFor(annotation = Retryable::class, attribute = "retryFor")
   val retryFor: Array<KClass<out Throwable>> = [
     WebClientResponseException.NotFound::class,
+    DiscardableNotFoundException::class,
   ],
 
   @get:AliasFor(annotation = Retryable::class, attribute = "backoff")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/queue/SQSMessageProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/personrecord/service/queue/SQSMessageProcessor.kt
@@ -25,7 +25,7 @@ class SQSMessageProcessor(
         NOTIFICATION -> action(sqsMessage)
       }
     } catch (_: DiscardableNotFoundException) {
-      log.info("Discarding message for status code")
+      log.error("Discarding message of type ${sqsMessage.getEventType()} due to discardable not found exception")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationAddressCreatedEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationAddressCreatedEventListenerIntTest.kt
@@ -59,8 +59,7 @@ class ProbationAddressCreatedEventListenerIntTest : ProbationEventListenerTestBa
     stubGetRequestToProbation(probationAddress, status = 404)
     publishProbationAddressCreatedEvent(cprPerson.crn, null, probationAddress.deliusAddressId, DELIUS)
 
-    expectNoMessagesOn(probationEventsQueue)
-    expectOneMessageOnDlq(probationEventsQueue)
+    expectNoMessagesOnQueueOrDlq(probationEventsQueue)
     expectNoMessagesOn(testOnlyCPRDomainEventsQueue)
     assertThat(personRepository.findByCrn(cprPerson.crn!!)!!.addresses.size).isEqualTo(0)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationAddressCreatedEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationAddressCreatedEventListenerIntTest.kt
@@ -2,10 +2,13 @@ package uk.gov.justice.digital.hmpps.personrecord.message.listeners.probation
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.system.CapturedOutput
+import org.springframework.boot.test.system.OutputCaptureExtension
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Address
 import uk.gov.justice.digital.hmpps.personrecord.service.DomainEventSource.DELIUS
 import uk.gov.justice.digital.hmpps.personrecord.test.randomCrn
-
+@ExtendWith(OutputCaptureExtension::class)
 class ProbationAddressCreatedEventListenerIntTest : ProbationEventListenerTestBase() {
 
   @Test
@@ -51,7 +54,7 @@ class ProbationAddressCreatedEventListenerIntTest : ProbationEventListenerTestBa
   }
 
   @Test
-  fun `consuming address created event - address not retrieved from probation - does not save address`() {
+  fun `consuming address created event - address not retrieved from probation - does not save address`(output: CapturedOutput) {
     val probationAddress = randomProbationAddress()
     val cprPerson = createRandomProbationPersonDetails()
     createPersonKey().addPerson(cprPerson)
@@ -62,6 +65,7 @@ class ProbationAddressCreatedEventListenerIntTest : ProbationEventListenerTestBa
     expectNoMessagesOnQueueOrDlq(probationEventsQueue)
     expectNoMessagesOn(testOnlyCPRDomainEventsQueue)
     assertThat(personRepository.findByCrn(cprPerson.crn!!)!!.addresses.size).isEqualTo(0)
+    awaitAssert { assertThat(output.all).contains("Discarding message of type probation-case.address.created due to discardable not found exception") }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationAddressUpdatedEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationAddressUpdatedEventListenerIntTest.kt
@@ -72,8 +72,7 @@ class ProbationAddressUpdatedEventListenerIntTest : ProbationEventListenerTestBa
 
     publishProbationAddressUpdatedEvent(personEntity.crn, probationAddress.deliusAddressId)
 
-    expectNoMessagesOn(probationEventsQueue)
-    expectOneMessageOnDlq(probationEventsQueue)
+    expectNoMessagesOnQueueOrDlq(probationEventsQueue)
 
     val actualPersonEntity = awaitNotNull { personRepository.findByCrn(personEntity.crn!!) }
     assertThat(actualPersonEntity.addresses.size).isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationAddressUpdatedEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationAddressUpdatedEventListenerIntTest.kt
@@ -5,10 +5,14 @@ import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.system.CapturedOutput
+import org.springframework.boot.test.system.OutputCaptureExtension
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Address
 import uk.gov.justice.digital.hmpps.personrecord.service.DomainEventSource.DELIUS
 import uk.gov.justice.digital.hmpps.personrecord.test.randomLowerCaseString
 
+@ExtendWith(OutputCaptureExtension::class)
 class ProbationAddressUpdatedEventListenerIntTest : ProbationEventListenerTestBase() {
 
   @Test
@@ -60,7 +64,7 @@ class ProbationAddressUpdatedEventListenerIntTest : ProbationEventListenerTestBa
   }
 
   @Test
-  fun `consuming address updated event - address not retrieved from probation - does not update address`() {
+  fun `consuming address updated event - address not retrieved from probation - does not update address`(output: CapturedOutput) {
     val probationAddress = randomProbationAddress()
     val personEntity = createPersonWithNewKey(
       createRandomProbationPersonDetails(),
@@ -78,6 +82,7 @@ class ProbationAddressUpdatedEventListenerIntTest : ProbationEventListenerTestBa
     assertThat(actualPersonEntity.addresses.size).isEqualTo(1)
     val cprAddressAfterUpdate = actualPersonEntity.addresses.first()
     assertThat(cprAddressAfterUpdate).usingRecursiveComparison().isEqualTo(cprAddressBeforeUpdate)
+    awaitAssert { assertThat(output.all).contains("Discarding message of type probation-case.address.updated due to discardable not found exception") }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationPersonRecoveredEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationPersonRecoveredEventListenerIntTest.kt
@@ -2,6 +2,9 @@ package uk.gov.justice.digital.hmpps.personrecord.message.listeners.probation
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.system.CapturedOutput
+import org.springframework.boot.test.system.OutputCaptureExtension
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Address
 import uk.gov.justice.digital.hmpps.personrecord.model.person.Person
 import uk.gov.justice.digital.hmpps.personrecord.service.eventlog.CPRLogEvents
@@ -9,6 +12,7 @@ import uk.gov.justice.digital.hmpps.personrecord.test.randomCrn
 import uk.gov.justice.digital.hmpps.personrecord.test.randomPostcode
 import uk.gov.justice.digital.hmpps.personrecord.test.responses.ApiResponseSetup
 
+@ExtendWith(OutputCaptureExtension::class)
 class ProbationPersonRecoveredEventListenerIntTest : ProbationEventListenerTestBase() {
 
   @Test
@@ -71,7 +75,7 @@ class ProbationPersonRecoveredEventListenerIntTest : ProbationEventListenerTestB
   }
 
   @Test
-  fun `should not recreate person if person does not exist in delius`() {
+  fun `should not recreate person if person does not exist in delius`(output: CapturedOutput) {
     val crn = randomCrn()
 
     stub404Response(probationUrl(crn))
@@ -85,5 +89,6 @@ class ProbationPersonRecoveredEventListenerIntTest : ProbationEventListenerTestB
       assertThat(personEntity).isNull()
     }
     expectNoMessagesOnQueueOrDlq(probationEventsQueue)
+    awaitAssert { assertThat(output.all).contains("Discarding message of type probation-case.engagement.recovered due to discardable not found exception") }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationPersonRecoveredEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationPersonRecoveredEventListenerIntTest.kt
@@ -71,7 +71,7 @@ class ProbationPersonRecoveredEventListenerIntTest : ProbationEventListenerTestB
   }
 
   @Test
-  fun `should fail to process if person does not exist in delius`() {
+  fun `should not recreate person if person does not exist in delius`() {
     val crn = randomCrn()
 
     stub404Response(probationUrl(crn))
@@ -84,6 +84,6 @@ class ProbationPersonRecoveredEventListenerIntTest : ProbationEventListenerTestB
       val personEntity = personRepository.findByCrn(crn)
       assertThat(personEntity).isNull()
     }
-    expectOneMessageOnDlq(probationEventsQueue)
+    expectNoMessagesOnQueueOrDlq(probationEventsQueue)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationUnmergeEventListenerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/personrecord/message/listeners/probation/ProbationUnmergeEventListenerIntTest.kt
@@ -4,6 +4,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.system.CapturedOutput
+import org.springframework.boot.test.system.OutputCaptureExtension
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.ProbationPersonUnmerged
 import uk.gov.justice.digital.hmpps.personrecord.client.model.sqs.messages.domainevent.ProbationPersonUnmergedInfo
 import uk.gov.justice.digital.hmpps.personrecord.config.MessagingMultiNodeTestBase
@@ -15,6 +18,7 @@ import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType
 import uk.gov.justice.digital.hmpps.personrecord.service.type.TelemetryEventType.CPR_UUID_CREATED
 import uk.gov.justice.digital.hmpps.personrecord.test.randomCrn
 
+@ExtendWith(OutputCaptureExtension::class)
 class ProbationUnmergeEventListenerIntTest : MessagingMultiNodeTestBase() {
 
   @Nested
@@ -326,7 +330,7 @@ class ProbationUnmergeEventListenerIntTest : MessagingMultiNodeTestBase() {
     }
 
     @Test
-    fun `should push 404 to dead letter queue`() {
+    fun `should discard if a 404 is received after retrying`(output: CapturedOutput) {
       val reactivatedCrn = randomCrn()
       val unmergedCrn = randomCrn()
       stub404Response(probationUrl(unmergedCrn))
@@ -339,7 +343,8 @@ class ProbationUnmergeEventListenerIntTest : MessagingMultiNodeTestBase() {
           ),
         ),
       )
-      expectOneMessageOnDlq(probationMergeEventsQueue)
+      expectNoMessagesOnQueueOrDlq(probationMergeEventsQueue)
+      awaitAssert { assertThat(output.all).contains("Discarding message of type probation-case.unmerge.completed due to discardable not found exception") }
     }
   }
 }


### PR DESCRIPTION
This is now needed because in dev Delius tests delete records without sending out events.
In practice, we don't get many 404's in production, so this would very rarely happen. We have enhanced logging to help detect when this happens.

# 🚨 READ THIS 🚨

Does this change...
* [ ] 🔨 Have any downstream breaking changes
* [ ] 🚩 Need Feature flagged
* [ ] 🔀 Require any database migrations
* [ ] 🔔 Alerting of any other teams of changes
* [ ] ☁️ Need to provision/update any cloud platform resources
* [ ] ⚡️ Benefit from running the [load tests](https://github.com/ministryofjustice/hmpps-person-record-gatling)
